### PR TITLE
fix(dccd): add .git/ ownership pre-flight check and auto-deploy on fresh server

### DIFF
--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 # Shell aliases and helper functions for TrueNAS NAS administration.
 #
-# Source this file from ~/.zshrc with a one-time addition:
-#   echo 'source /mnt/vm-pool/apps/scripts/aliases.sh' >> ~/.zshrc
+# Source this file from your shell's RC file with a one-time addition:
+#   zsh:  echo 'source /mnt/vm-pool/apps/scripts/aliases.sh' >> ~/.zshrc
+#   bash: echo 'source /mnt/vm-pool/apps/scripts/aliases.sh' >> ~/.bashrc
 #
 # After that, dccd.sh keeps this file up-to-date automatically on every git pull.
 

--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -487,6 +487,22 @@ update_compose_files() {
         # Ignore file permission changes (init containers chown/chmod volumes, which should not dirty the working tree)
         GIT_OPTS=(-c "url.https://github.com/.insteadOf=git@github.com:" -c "safe.directory=${dir}" -c "core.filemode=false")
 
+        # Pre-flight: detect .git/ files not owned by the current user (e.g. FETCH_HEAD
+        # created by a previous root run). git fetch will fail to write to these files.
+        local bad_git_files current_user
+        current_user=$(whoami) || true
+        bad_git_files=$(find "${dir}/.git" -maxdepth 2 ! -user "$(id -u)" -print 2>/dev/null) || true
+        if [ -n "${bad_git_files}" ]; then
+            log_message "ERROR: .git/ contains files not owned by the current user (${current_user}):"
+            local file_owner
+            while IFS= read -r f; do
+                file_owner=$(stat -c '%U' "${f}" 2>/dev/null) || file_owner="unknown"
+                log_message "ERROR:   ${f}  (owner: ${file_owner})"
+            done <<<"${bad_git_files}"
+            log_message "ERROR: Fix with: sudo chown -R ${current_user} ${dir}/.git"
+            exit 1
+        fi
+
         # Check if there are any changes in the Git repository
         if ! git "${GIT_OPTS[@]}" fetch --quiet origin; then
             log_message "ERROR: Unable to fetch changes from the remote repository (the server may be offline or unreachable)"
@@ -703,8 +719,10 @@ update_compose_files() {
         while IFS= read -r f; do
             log_message "WARNING:   ${f}"
         done <<<"${root_owned}"
+        local current_user
+        current_user=$(whoami) || true
         log_message "WARNING: To fix, run manually:"
-        log_message "WARNING:   find \"${BASE_DIR}\" \\( -name data -o -name backups \\) -prune -o -user root -print0 | xargs -0 -r sudo chown truenas_admin:truenas_admin"
+        log_message "WARNING:   find \"${BASE_DIR}\" \\( -name data -o -name backups \\) -prune -o -user root -print0 | xargs -0 -r sudo chown ${current_user}:${current_user}"
     fi
 
     if [ "${SHOULD_DEPLOY}" -eq 1 ]; then

--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -546,7 +546,15 @@ update_compose_files() {
 
             SHOULD_DEPLOY=1
         else
-            log_message "STATE: Already up-to-date on origin/${REMOTE_BRANCH} (${short_local}) — nothing to do"
+            # Even when up-to-date, deploy if no containers are running (fresh server)
+            local running_containers
+            running_containers=$(${SUDO} docker ps --quiet 2>/dev/null | head -1) || true
+            if [ -z "${running_containers}" ]; then
+                log_message "STATE: Already up-to-date on origin/${REMOTE_BRANCH} (${short_local}) but no containers running — deploying"
+                SHOULD_DEPLOY=1
+            else
+                log_message "STATE: Already up-to-date on origin/${REMOTE_BRANCH} (${short_local}) — nothing to do"
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Problem

On the new \`svlazext\` server, \`dccd.sh\` failed with:

\`\`\`
error: cannot open '.git/FETCH_HEAD': Permission denied
ERROR: Unable to fetch changes from the remote repository
\`\`\`

This happened because \`.git/FETCH_HEAD\` was owned by root from a previous run. Additionally, after fixing permissions, the script skipped deployment because local and remote hashes matched — even though no containers were running (fresh server).

## Changes

### \`scripts/dccd.sh\`
- **Pre-flight \`.git/\` ownership check** — Before \`git fetch\`, scan \`.git/\` for files not owned by the current user and exit with a clear error message and fix command
- **Auto-deploy when no containers are running** — When hashes match but \`docker ps\` shows nothing running, trigger deployment instead of skipping (handles fresh server case)
- **Dynamic username in fix commands** — Post-deployment root-owned-files warning now uses \`whoami\` instead of hardcoded \`truenas_admin\`

### \`scripts/aliases.sh\`
- Minor improvements to user instructions

### \`.mise.toml\`
- Tool version updates