### PR TITLE
feat(image-security): refactor age-check into function and auto-close resolved stale issues

### DIFF
--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -3,6 +3,10 @@ name: Image Security
 
 on:
   pull_request:
+    paths:
+      - .github/workflows/image-security.yml
+      - scripts/gha-image-age-check.sh
+      - scripts/gha-trivy-image-scan.sh
   schedule:
     - cron: "0 2 * * 6"
   workflow_dispatch:
@@ -21,7 +25,6 @@ permissions:
 jobs:
   image-age-check:
     name: Image age check
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -3,6 +3,10 @@ name: Label Sync
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/labels.yaml
+      - .github/workflows/label-sync.yml
   push:
     branches:
       - main

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,14 +49,14 @@ services:
 - Images must always include an explicit registry prefix (e.g. `docker.io/library/busybox`, `ghcr.io/gethomepage/homepage`). Bare image names like `busybox` or `user/image` are not allowed — Docker's implicit `docker.io` default is not reliable across runtimes and Renovate cannot enforce the correct registry without it
 - Images are digest-pinned (`@sha256:...`) — Renovate manages updates via PRs
 - **Prefer the smallest, most hardened image variant available** for a given version tag. When multiple variants are published, choose according to this priority order:
-    1. **Hardened** (e.g., `-hardened`, Chainguard distroless/static images, Docker Hub Hardened Images at `docker.io/hardened-images/dhi/<name>`) — minimal attack surface, no shell, stripped of unnecessary OS components. Note that hardened variants are sometimes published under a **different image name or registry** rather than as a tag suffix on the official image (e.g., `eclipse-mosquitto` has a hardened build at `docker.io/hardened-images/dhi/eclipse-mosquitto`). Always check the [Docker Hub Hardened Images catalog](https://hub.docker.com/u/hardened-images) and [Chainguard](https://www.chainguard.dev/chainguard-images) for a hardened alternative before falling back to Alpine.
-    2. **Alpine** (e.g., `2.1.2-alpine`) — musl-based, ~5 MB base layer, no unnecessary tools
-    3. **Slim** (e.g., `2.1.2-slim`) — Debian-based with non-essential packages removed
-    4. **Standard** (e.g., `2.1.2`) — only when no smaller or hardened variant exists, or when the application requires glibc/full Debian (e.g., for `apt` at runtime or native library dependencies)
+  1. **Hardened** (e.g., `-hardened`, Chainguard distroless/static images, Docker Hub Hardened Images at `docker.io/hardened-images/dhi/<name>`) — minimal attack surface, no shell, stripped of unnecessary OS components. Note that hardened variants are sometimes published under a **different image name or registry** rather than as a tag suffix on the official image (e.g., `eclipse-mosquitto` has a hardened build at `docker.io/hardened-images/dhi/eclipse-mosquitto`). Always check the [Docker Hub Hardened Images catalog](https://hub.docker.com/u/hardened-images) and [Chainguard](https://www.chainguard.dev/chainguard-images) for a hardened alternative before falling back to Alpine.
+  2. **Alpine** (e.g., `2.1.2-alpine`) — musl-based, ~5 MB base layer, no unnecessary tools
+  3. **Slim** (e.g., `2.1.2-slim`) — Debian-based with non-essential packages removed
+  4. **Standard** (e.g., `2.1.2`) — only when no smaller or hardened variant exists, or when the application requires glibc/full Debian (e.g., for `apt` at runtime or native library dependencies)
 
-    When choosing a variant, verify it provides the required functionality (some Alpine builds omit optional compiled modules). Document any exception in a comment in the compose file.
+  When choosing a variant, verify it provides the required functionality (some Alpine builds omit optional compiled modules). Document any exception in a comment in the compose file.
 
-    If an image publishes additional non-standard variant suffixes (e.g., `-openssl`, `-jdk`, `-bookworm`, `-ubi9`) that are not covered by the priority order above, **ask the user which variant is preferred** before selecting one — the implications (library compatibility, licence, FIPS compliance, etc.) are context-dependent.
+  If an image publishes additional non-standard variant suffixes (e.g., `-openssl`, `-jdk`, `-bookworm`, `-ubi9`) that are not covered by the priority order above, **ask the user which variant is preferred** before selecting one — the implications (library compatibility, licence, FIPS compliance, etc.) are context-dependent.
 - `read_only: true` with `tmpfs` mounts for writable paths
 - `no-new-privileges` on every container, no exceptions
 - `cap_drop: ALL` on every container — this is a hard security requirement. If a container needs a specific capability, declare `cap_add` with only the minimum required capability and add a comment on the container in the compose file explaining why the exception is necessary

--- a/scripts/gha-image-age-check.sh
+++ b/scripts/gha-image-age-check.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Called by .github/workflows/stale-images.yml (image-age-check job).
+# Called by .github/workflows/image-security.yml (image-age-check job).
 # Reads all image: references from services/*/compose.yaml, determines when each
 # tag was last pushed to its registry, opens a GitHub issue for each image
-# that has not been updated in more than THRESHOLD_DAYS days, then exits 1
-# if any stale images were found.
+# that has not been updated in more than THRESHOLD_DAYS days, and closes any
+# previously-opened stale-dependency issues whose image has since been updated.
 #
 # Timestamp sources (in priority order):
 #   docker.io  — Docker Hub REST API `tag_last_pushed` (registry-side, always
@@ -17,19 +17,24 @@
 
 set -euo pipefail
 
-THRESHOLD=$(date -d "${THRESHOLD_DAYS} days ago" +%s)
 STALE=()
 
-# SC2312: set -o pipefail (via set -euo pipefail above) already surfaces pipeline
-# failures — the per-stage warning is a false positive in this context.
-# shellcheck disable=SC2312
-while IFS= read -r full_image; do
-    # Strip @sha256:... to get the name:tag for display (keep the version)
-    bare="${full_image%%@*}"
-    echo "Checking ${bare}..."
+# get_age_days IMAGE
+#
+# Prints the age in whole days of IMAGE (name:tag, no digest suffix).
+# Prints "skip" instead if the image carries a placeholder/zero timestamp
+# (reproducible-build images that do not track real push dates).
+# Returns 1 if the age cannot be determined (registry unreachable, etc.).
+#
+# Timestamp strategy:
+#   docker.io  — Docker Hub REST API `tag_last_pushed` (always updated on push)
+#   all others — OCI config `created` via crane
+get_age_days() {
+    local bare="${1}"
+    local last_pushed=""
+    local pushed_ts
+    local now
 
-    # Determine the "last pushed" timestamp for this image.
-    #
     # The OCI config `created` field is a compile-time value baked into the
     # image layers by the build system.  Some maintainers (notably official
     # Docker Library images such as busybox) do NOT update it when rebuilding
@@ -41,52 +46,78 @@ while IFS= read -r full_image; do
     #                registry-side timestamp that is always updated on push.
     #   all others — GHCR, LSCR, etc. set OCI `created` accurately on every
     #                release, so the crane config fallback remains reliable.
-    last_pushed=""
-    source_label="created"
     case "${bare}" in
     docker.io/*)
+        local remainder
+        local ns_repo
+        local tag_part
+        local dh_url
+        local dh_out
         remainder="${bare#docker.io/}"
         ns_repo="${remainder%%:*}"
         tag_part="${remainder#*:}"
         dh_url="https://hub.docker.com/v2/repositories/${ns_repo}/tags/${tag_part}"
         if dh_out=$(curl -fsSL --max-time 10 "${dh_url}" 2>/dev/null); then
             last_pushed=$(echo "${dh_out}" | jq -r '.tag_last_pushed // empty')
-            source_label="last_pushed"
         fi
         ;;
     *) ;;
     esac
 
     if [ -z "${last_pushed}" ]; then
+        local crane_out
         if ! crane_out=$(crane config "${bare}" 2>/dev/null); then
-            echo "  WARN: crane could not fetch config for ${bare}, skipping"
-            continue
+            echo ""
+            return 0
         fi
         last_pushed=$(echo "${crane_out}" | jq -r '.created // empty')
     fi
 
     if [ -z "${last_pushed}" ]; then
-        echo "  WARN: could not determine push date for ${bare}, skipping"
-        continue
+        echo ""
+        return 0
     fi
 
-    # Skip zero-time / reproducible-build placeholder timestamps
+    # Skip zero-time / reproducible-build placeholder timestamps.
     case "${last_pushed}" in
     "0001-01-01"* | "1970-01-01"*)
-        echo "  SKIP: ${bare} has a zero-time placeholder timestamp (reproducible build image)"
-        continue
+        echo "skip"
+        return 0
         ;;
     *) ;;
     esac
 
     pushed_ts=$(date -d "${last_pushed}" +%s)
-    age_days=$((($(date +%s) - pushed_ts) / 86400))
+    now=$(date +%s)
+    echo $(((now - pushed_ts) / 86400))
+}
 
-    if [ "${pushed_ts}" -lt "${THRESHOLD}" ]; then
-        echo "  STALE: ${bare} (${source_label}: ${last_pushed}, ${age_days} days ago)"
+# --- Scan all images in compose files and build the STALE list ---------------
+
+# SC2312: set -o pipefail (via set -euo pipefail above) already surfaces pipeline
+# failures — the per-stage warning is a false positive in this context.
+# shellcheck disable=SC2312
+while IFS= read -r full_image; do
+    # Strip @sha256:... to get the name:tag for display (keep the version)
+    bare="${full_image%%@*}"
+    echo "Checking ${bare}..."
+
+    age_days=$(get_age_days "${bare}")
+    if [ -z "${age_days}" ]; then
+        echo "  WARN: could not determine push date for ${bare}, skipping"
+        continue
+    fi
+
+    if [ "${age_days}" = "skip" ]; then
+        echo "  SKIP: ${bare} has a zero-time placeholder timestamp (reproducible build image)"
+        continue
+    fi
+
+    if [ "${age_days}" -gt "${THRESHOLD_DAYS}" ]; then
+        echo "  STALE: ${bare} (${age_days} days old)"
         STALE+=("${full_image}")
     else
-        echo "  OK:    ${bare} (${source_label}: ${last_pushed}, ${age_days} days ago)"
+        echo "  OK:    ${bare} (${age_days} days old)"
     fi
 done < <(
     grep -rh 'image:' services/*/compose.yaml |
@@ -96,47 +127,115 @@ done < <(
         sort -u
 )
 
+# --- Open new issues for freshly discovered stale images ---------------------
+
 if [ "${#STALE[@]}" -eq 0 ]; then
     echo "All images are within the ${THRESHOLD_DAYS}-day threshold."
-    exit 0
-fi
+else
+    printf '\nStale images detected: %d\n' "${#STALE[@]}"
+    for image in "${STALE[@]}"; do
+        echo "  - ${image}"
+    done
+    echo ""
 
-printf '\nStale images detected: %d\n' "${#STALE[@]}"
-for image in "${STALE[@]}"; do
-    echo "  - ${image}"
-done
-echo ""
-
-for image in "${STALE[@]}"; do
-    # Strip digest for the issue title so it stays readable
-    title_image="${image%%@*}"
-    title="[${title_image}] Stale image detected"
-    existing=$(gh issue list \
-        --label stale-dependency \
-        --state open \
-        --json title \
-        --jq '.[].title' |
-        grep -F "${title}" || true)
-
-    if [ -z "${existing}" ]; then
-        # Find compose files that reference this image by name:tag
-        # SC2312: pipefail is active; grep returning no matches exits 1 which
-        # we handle explicitly with || true.
-        # shellcheck disable=SC2312
-        sources=$(grep -rl "${title_image}" services/*/compose.yaml 2>/dev/null |
-            sort | tr '\n' '\n' | sed 's|^|  - |' || true)
-        [ -z "${sources}" ] && sources="  - (not found via grep)"
-        gh issue create \
-            --title "${title}" \
+    for image in "${STALE[@]}"; do
+        # Strip digest for the issue title so it stays readable
+        title_image="${image%%@*}"
+        title="[${title_image}] Stale image detected"
+        existing=$(gh issue list \
             --label stale-dependency \
-            --body "The pinned digest for \`${image}\` was built over ${THRESHOLD_DAYS} days ago.
+            --state open \
+            --json title \
+            --jq '.[].title' |
+            grep -F "${title}" || true)
+
+        if [ -z "${existing}" ]; then
+            # Find compose files that reference this image by name:tag
+            # SC2312: pipefail is active; grep returning no matches exits 1 which
+            # we handle explicitly with || true.
+            # shellcheck disable=SC2312
+            sources=$(grep -rl "${title_image}" services/*/compose.yaml 2>/dev/null |
+                sort | tr '\n' '\n' | sed 's|^|  - |' || true)
+            [ -z "${sources}" ] && sources="  - (not found via grep)"
+            gh issue create \
+                --title "${title}" \
+                --label stale-dependency \
+                --body "The pinned digest for \`${image}\` was built over ${THRESHOLD_DAYS} days ago.
 
 **Found in:**
 ${sources}
 
 Please update the image digest to a more recent version to reduce exposure to known security vulnerabilities. If Renovate is not auto-updating this image, check whether the registry exposes reliable timestamp metadata."
-        echo "Created issue: ${title}"
-    else
-        echo "Issue already exists, skipping: ${title}"
+            echo "Created issue: ${title}"
+        else
+            echo "Still stale, issue already open: ${title}"
+        fi
+    done
+fi
+
+# --- Close resolved stale-dependency issues ----------------------------------
+# Re-check each open stale-dependency issue against the current image in the
+# compose files. If the image is now fresh (or has been removed entirely),
+# close the issue automatically.
+
+printf '\nChecking open stale-dependency issues for resolution...\n'
+
+# shellcheck disable=SC2312
+while IFS= read -r issue_json; do
+    issue_number=$(printf '%s' "${issue_json}" | jq -r '.number')
+    issue_title=$(printf '%s' "${issue_json}" | jq -r '.title')
+
+    # Only process issues matching the expected "[image:tag] Stale image detected" format.
+    case "${issue_title}" in
+    *"] Stale image detected") ;;
+    *)
+        echo "  SKIP: issue #${issue_number} does not match expected title format"
+        continue
+        ;;
+    esac
+
+    # Extract the image name:tag from between the surrounding brackets.
+    title_image="${issue_title#[}"
+    title_image="${title_image%%]*}"
+
+    # Find the current full image reference (with digest) in compose files.
+    # shellcheck disable=SC2312
+    current_full=$(grep -rh 'image:' services/*/compose.yaml |
+        grep -v '^[[:space:]]*#' |
+        sed 's/.*image:[[:space:]]*//' |
+        tr -d "'" |
+        grep -F "${title_image}@" | head -1 || true)
+
+    if [ -z "${current_full}" ]; then
+        echo "  ${title_image}: no longer in any compose file — closing issue #${issue_number}"
+        gh issue close "${issue_number}" \
+            --comment "This image is no longer referenced in any compose file. Closing automatically."
+        continue
     fi
-done
+
+    current_bare="${current_full%%@*}"
+    age_days=$(get_age_days "${current_bare}")
+    if [ -z "${age_days}" ]; then
+        echo "  WARN: could not re-check age for ${current_bare}, skipping issue #${issue_number}"
+        continue
+    fi
+
+    if [ "${age_days}" = "skip" ]; then
+        echo "  SKIP: ${current_bare} has a placeholder timestamp — skipping issue #${issue_number}"
+        continue
+    fi
+
+    if [ "${age_days}" -le "${THRESHOLD_DAYS}" ]; then
+        echo "  RESOLVED: ${current_bare} is now ${age_days} days old — closing issue #${issue_number}"
+        gh issue close "${issue_number}" \
+            --comment "The image \`${current_bare}\` is no longer stale (${age_days} days old, threshold: ${THRESHOLD_DAYS} days). Closing automatically."
+    else
+        echo "  STILL STALE: ${current_bare} (${age_days} days old) — issue #${issue_number} remains open"
+    fi
+done < <(
+    gh issue list \
+        --label stale-dependency \
+        --state open \
+        --json number,title |
+        jq -c '.[]'
+)


### PR DESCRIPTION
Closes #177

## Summary

Refactors `scripts/gha-image-age-check.sh` to extract the registry timestamp logic into a reusable `get_age_days` function, and adds a resolution pass that automatically closes stale-dependency issues when the underlying image has been updated.

## Changes

### `get_age_days` function

Extracts the Docker Hub API + crane fallback + zero-time placeholder logic into a single reusable function. Always returns exit code 0; signals errors via empty output (avoids SC2310 from the `check-set-e-suppressed` shellcheck rule). Callers check for empty output rather than using `||` conditionals.

### Simplified scan loop

The main image scan loop now just calls `get_age_days` and compares the result as integer days against `THRESHOLD_DAYS` directly — no more `THRESHOLD` unix-timestamp variable.

### Auto-close resolved issues

After opening new issues, the script now iterates all open `stale-dependency` issues and:
- **Closes** issues where the image is no longer referenced in any compose file (service removed/retired)
- **Closes** issues where `get_age_days` reports the current digest age is ≤ `THRESHOLD_DAYS` (Renovate updated the image), with an explanatory comment
- **Skips** issues whose title doesn't match the expected format

Previously the script would silently skip already-open issues even if they'd been resolved by a Renovate merge.