### PR TITLE
fix(adguard): require password on adguard-redis (closes #189)

### DIFF
--- a/services/adguard/compose.yaml
+++ b/services/adguard/compose.yaml
@@ -58,7 +58,14 @@ services:
       - ""
       - "--tcp-keepalive"
       - "60"
+      # Password protection — the same value must appear in cachedb.conf via
+      # adguard-unbound-init substitution. Argv form avoids shell parsing of
+      # special characters in the password.
+      - "--requirepass"
+      - "${ADGUARD_REDIS_PASSWORD}"
     env_file:
+      - path: .env # Decrypted from secret.sops.env
+        required: false
       - path: ../shared/env/tz.env
     deploy:
       update_config:
@@ -80,9 +87,18 @@ services:
     tmpfs:
       - /tmp
     healthcheck:
+      # CMD (exec form) — the dhi.io/redis hardened image is distroless and
+      # does NOT ship /bin/sh, so CMD-SHELL fails with "no such file" and the
+      # container is reported unhealthy even when redis is up. Pass the password
+      # as a discrete argv element so compose interpolation is safe (no shell
+      # parsing of special characters). redis-cli ping exits 0 on PONG, non-zero
+      # on connect/auth failure.
       test:
         - "CMD"
         - "redis-cli"
+        - "--no-auth-warning"
+        - "-a"
+        - "${ADGUARD_REDIS_PASSWORD}"
         - "ping"
       interval: 10s
       timeout: 5s
@@ -136,7 +152,7 @@ services:
     volumes:
       - ./data/unbound/conf.d/a-records.conf:/usr/local/unbound/conf.d/a-records.conf:ro
       - ./data/unbound/conf.d/server-overrides.conf:/usr/local/unbound/conf.d/server-overrides.conf:ro
-      - ./config/unbound/conf.d/cachedb.conf:/usr/local/unbound/conf.d/cachedb.conf:ro
+      - ./data/unbound/conf.d/cachedb.conf:/usr/local/unbound/conf.d/cachedb.conf:ro
       - ./config/unbound/conf.d/remote-control.conf:/usr/local/unbound/conf.d/remote-control.conf:ro
       - ./data/unbound/zones.d/forward-zones.conf:/usr/local/unbound/zones.d/forward-zones.conf:ro
       # Required only when tls-cert-bundle is enabled in server-overrides.conf (DoT forward zones):

--- a/services/adguard/config/unbound/conf.d/cachedb.conf
+++ b/services/adguard/config/unbound/conf.d/cachedb.conf
@@ -1,9 +1,12 @@
 # Persistent DNS cache backend using Redis (adguard-redis container).
-# Mounted directly — no ${VAR} placeholders, no envsubst needed.
+# ${ADGUARD_REDIS_PASSWORD} is substituted by adguard-unbound-init at deploy
+# time from secret.sops.env. The same value is passed to redis-server via
+# --requirepass in compose.yaml.
 # Loaded via include-toplevel: in unbound.conf — must start a clause.
 
 cachedb:
     backend: "redis"
     redis-server-host: adguard-redis
     redis-server-port: 6379
+    redis-server-password: "${ADGUARD_REDIS_PASSWORD}"
     redis-expire-records: yes

--- a/services/adguard/config/unbound/envsubst.sh
+++ b/services/adguard/config/unbound/envsubst.sh
@@ -9,7 +9,7 @@ set -eu
 
 mkdir -p /output/conf.d /output/zones.d
 
-for f in conf.d/a-records.conf conf.d/server-overrides.conf zones.d/forward-zones.conf; do
+for f in conf.d/a-records.conf conf.d/server-overrides.conf conf.d/cachedb.conf zones.d/forward-zones.conf; do
     cp "/templates/${f}" "/output/${f}"
     # shellcheck disable=SC2312  # grep/sort exit codes are intentionally unmasked; empty output is handled
     grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' "/templates/${f}" | sort -u | while read -r pattern; do
@@ -23,7 +23,7 @@ done
 # Verify no unresolved placeholders remain — catches missing secret.sops.env entries
 # before unbound starts with a broken config. Fails the init container loudly.
 failed=0
-for f in conf.d/a-records.conf conf.d/server-overrides.conf zones.d/forward-zones.conf; do
+for f in conf.d/a-records.conf conf.d/server-overrides.conf conf.d/cachedb.conf zones.d/forward-zones.conf; do
     # shellcheck disable=SC2312
     unresolved=$(grep -onE '\$\{[A-Z_][A-Z0-9_]*\}' "/output/${f}" 2>/dev/null || true)
     if [ -n "${unresolved}" ]; then

--- a/services/adguard/secret.sops.env
+++ b/services/adguard/secret.sops.env
@@ -1,27 +1,29 @@
-#ENC[AES256_GCM,data:jTektc50pLh7OooXlPnPckwSmaMhg0Mc8cmDdifZTlQ=,iv:DWdwAOgQ7OOZDozR3OM5ipv0oPa4d9PY2NXbGwWrgYI=,tag:3xIhC8IFHNyiyvk91ZbrXQ==,type:comment]
-DOMAINNAME=ENC[AES256_GCM,data:JEvGZKZHz7syjuCvnt4=,iv:p7GriSXUIZDkuWdpapfhncJ1filstrs+BeYnVwXiiOw=,tag:wIJ2CS7OLe+qTMoVqBywAA==,type:str]
-#ENC[AES256_GCM,data:IdRDc/szb4y7SFBgIum+NIku3F8=,iv:pguKhGwcxUbD4z2XAooQIDCEw/WJ54+zY1lraBwk8Hg=,tag:A1dSmBK4W1gcxi2U1R3idg==,type:comment]
-DDNS_DOMAIN=ENC[AES256_GCM,data:XPLnXJ5CYJopFqyMNhiAeQlOwwjz/b/G7PkabLpsI+Q6m65M9N0gVIpNoa+1Z6w=,iv:c2cMQGx1imjFDuY1jwKrSpJhGQC7BoUi21OzlKRA1/A=,tag:ZY0f0IOurOiEcL/Np0hFWA==,type:str]
-#ENC[AES256_GCM,data:nFqsXRNCDv86oILX6kxc6lFqDqnu,iv:T5K7au6IB3szIbM4YGij+n3Vh4/W6nE86n6fEc2WTw4=,tag:N19Gor1ni00WbMPskDgSnQ==,type:comment]
-IP_HOME=ENC[AES256_GCM,data:BXsO3SIMIRb3+8g7,iv:B42rPvE7K/o9Fd36noTznAkUaJroVjoXJkFLJpIHc20=,tag:cHpabDs4pb23Af4pesAW8A==,type:str]
-IP_K8S_DNS=ENC[AES256_GCM,data:ji7OFNh3pSnB5ieH2w==,iv:2qUje27OBNIOOdH8i+cAV84KAh7xyYqdggw84mEEUCc=,tag:tXD71yZjeD6b1CE0yT3kDg==,type:str]
-IP_SVLAPPS=ENC[AES256_GCM,data:PYOonWmzGWFi6d5g,iv:R6ZgZSX8Bf1DWlQ/BdROISiwoBXNCgz2rOb4t1353bA=,tag:YtSzOmkl7fWTfVP2cXs3vw==,type:str]
-IP_SVLDEV=ENC[AES256_GCM,data:mUPuPBOeISjbiyRE,iv:lgbFYmuEV9OIsnSq+gTzymqEyCn51HmaaxTpqot8JtE=,tag:HUXSz2vjqCbsW0IGPRS52g==,type:str]
-IP_SVLINFRA=ENC[AES256_GCM,data:Hymz4BnfCx+OSwjz,iv:cNKgtDjy3iecx/JYEv/bkLNCX9pSc3MKn4LnhvR6nT4=,tag:NEApMy8qh7x1kR9JgihUSg==,type:str]
-IP_SVLMEDIA=ENC[AES256_GCM,data:yc/jyXWJZWHLgQhZ,iv:uCfJEN7qHI346s9+HTHVthmWvRYknswfqeXSj1d7iw0=,tag:BBa49novwN+YkerSrx3S7A==,type:str]
-IP_SVLNAS=ENC[AES256_GCM,data:thijIHKIflYA5RAX,iv:8cXK0Z9Lz7cc4PbRiqvFboZBJB04LkH8VPyAeANG6W8=,tag:P7KhbBrrnWjjk5b7ZG6H/g==,type:str]
-IP_SVLPROD=ENC[AES256_GCM,data:DVu6mpRCaFAgP46P,iv:sZDbfhPIXvRKHewPIjfX+bRx0vcR4MgQ9Qj5Ca5O5Ag=,tag:Nb6q+oeGev29wJTKjcSfcA==,type:str]
-#ENC[AES256_GCM,data:7n6UcReXEwCFIgjPIJImwE/cf5y/h/1yBmHIpA3bWVQ=,iv:5OKoqD2d9/xmeXwa1uHQ4eaiZ0e/q+Av9t2G84+kAiE=,tag:0ciFjCFxJeQIZl3EBcpilA==,type:comment]
-IP_SVLEXT=ENC[AES256_GCM,data:LkB+qZQdTLvvBV7hIw==,iv:m2uoUiXuUes37s5L91oSq3wwO3U8lX9s+9zhY1s0TxU=,tag:j97tq+J6dYmInm23mD8xpg==,type:str]
-IP_SVLDMZ=ENC[AES256_GCM,data:8LhFbOVuCEJKScs2,iv:bfNUKQy5HaBjbEf1wqgxlg/xB+eq9hgLk9BmfV8ANvs=,tag:4r2eysiaGk5NdY/q9wMDXA==,type:str]
-IP_SVLAZEXT=ENC[AES256_GCM,data:CMeKmjCJwnbtZGVU,iv:3QuoHdWOGNzSabzom4K2HS3e+X82TJClW+3AgtO3Gs8=,tag:jCJpesnTnqdxKLaafvdaHg==,type:str]
-sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBoZm5TeGl4bXBudDJhblZn\ndlZKNDlETm5QMVVDVUhHejlwejRkT3FxeWg0CjBjTUg1KzZGYjF0c0t4NEJEWmR2\nTnZPNThVVVBnZkdmRUhDNHVoUjUwR0UKLS0tIDJHSWJEN2xSRk1RUS9uM3dDbHIz\nRWF1ZUdCQ2xpcVdraXRjNllyRHVkSDQK6NrM+sfJlV5x7tlr8xkcyqI70CPcxtvu\nqLhDaNwHkMKi7YLt3H/0gfb2Arr5H9xt/ZnTp8O7WaMv1sFjg2IaeA==\n-----END AGE ENCRYPTED FILE-----\n
+#ENC[AES256_GCM,data:XlKNwVIiY0OmB1i9TQaqAOgUfqx6Mih4wlgCCmspf6o=,iv:WfJum2ut+8KSbtgZokbEn77opUyHf23hNfoX9YM7Br8=,tag:F7kTAINdGYZ3/70wRIHWiQ==,type:comment]
+DOMAINNAME=ENC[AES256_GCM,data:lgBMpxF6zyAzVoYFqSk=,iv:9+Xa3R+SyvwHntk5y6AOLuw/580dRh0cdpBaTqxoRWI=,tag:0edUlmWV8d9Q5rn3eRf3+A==,type:str]
+#ENC[AES256_GCM,data:rYu0aWD1mrACpWXYMVc1EW6Eby8=,iv:e2oWGOQM0JRKLlda6/cIeu9GsWW821ZKoXr4CSOAM6M=,tag:IJLj0sHy7Ykg8geZYmYneA==,type:comment]
+DDNS_DOMAIN=ENC[AES256_GCM,data:IaP+4uo2yitzAIMc0t6VFtZHDt1HmRe+BoIb3tD/kG9BWs72/ubYa58LaNrEaAU=,iv:GMb4Iws2EjwmpQU13oPr5eLgbFDychFoSByKKj6Alb8=,tag:m5egGsdOcSid0jWbYdIG5w==,type:str]
+#ENC[AES256_GCM,data:/83qugh/k4DRtYK5zO1vbuP3GUQo,iv:QQCkk7+mdzBSVbuOtNtzPyC3HGnZJvAVRtwe9S3HGEU=,tag:C+m+VX6B7ln49wv6s/JArg==,type:comment]
+IP_HOME=ENC[AES256_GCM,data:YsPUCwl2b3AG+Ey0,iv:fX2wswx93xugCHgx8Wsi4/qAYENBF/uUDAcM60F2FlU=,tag:ELqdQgwqBqGmu3yMGmh/FQ==,type:str]
+IP_K8S_DNS=ENC[AES256_GCM,data:/t8+vZ6A00Cfb3LxXg==,iv:/F0wQAsuRPSLutcK3W8ewp9aMZi3Wv7rUCN8hXLAGdA=,tag:y2kSJ3S3j8/qenAALoAo+Q==,type:str]
+IP_SVLAPPS=ENC[AES256_GCM,data:rG02dbrlZGXIgPPM,iv:hZ+Hy3CppQs6vyF9K+2HZxbzEHohXF9zaAwwcIebzoE=,tag:LtWOit8F7Ducx/vywbpvTg==,type:str]
+IP_SVLDEV=ENC[AES256_GCM,data:xIhDaGdAKErTo7Y0,iv:K1yrB/BDUe0FqidmRks+wtVARRyoLotALjlFtKvWUmk=,tag:hBgWmYjRPzyjoDkwX1yX4Q==,type:str]
+IP_SVLINFRA=ENC[AES256_GCM,data:Q+iHgfal+nyBgiAj,iv:JG1o3bFOvqzU4/UIrm2LJ1FjXdO/5NyXgKA9cBPNVD8=,tag:nbVtjgFs+g6XfvwCiZF+4Q==,type:str]
+IP_SVLMEDIA=ENC[AES256_GCM,data:OoR2P1dBDMLXFDWG,iv:EyhSL6t32juHECcnZTtEfhmk+itBpM0I3DEj50Cu8aY=,tag:X36oA3GQLppSoK0/3VsNgg==,type:str]
+IP_SVLNAS=ENC[AES256_GCM,data:izA6c4Uqiy+OpHcK,iv:qvgI2Xi9lz+RBL0vQ3+KJAiMxnd8A15i1+34GLjeyPo=,tag:Mtq61As3wJ6gE5ueGjy4eA==,type:str]
+IP_SVLPROD=ENC[AES256_GCM,data:UlKkQEMJHqwWp+QF,iv:AzLu+Ah6lHfYV0fslqq6HAQe+q6rHcZosTPcV8M3IiU=,tag:ae+bfr/8e0BVdfeguZtdRg==,type:str]
+#ENC[AES256_GCM,data:QdwNnKzAS9puhZWS6y63J1ZCGwj3qHe9j0cnMGvzjiA=,iv:MEsGj4EP/P5TjSIu1tz8FT942ZgUU9kv7jAntH4WKog=,tag:gRvaiuMaJxHpsbNdmT+2MQ==,type:comment]
+IP_SVLEXT=ENC[AES256_GCM,data:hI/w45AgTvggMa0oKg==,iv:JYpyNmW618L6ZUQl/WRkrLhgROokLtdQTIonbNlrOzk=,tag:bJ9X1IQwuXffJobj6BxpRg==,type:str]
+IP_SVLDMZ=ENC[AES256_GCM,data:teQhtEer5dOBGY32,iv:5sWtMsxYtebBHsuXA5VMuVTKIyGYUB3sw4OZnKLP/uE=,tag:ot8AZaGfH2RDXfJWFuKmhQ==,type:str]
+IP_SVLAZEXT=ENC[AES256_GCM,data:7sZJ5MclPDTL4mOg,iv:8491LZz3poUnQTFb1T22AbFb67myg3kjprrRha+5QXg=,tag:baRpJ2A4NWHY27P6C0AZqQ==,type:str]
+#ENC[AES256_GCM,data:PutewlNq1FpRuPlg3nsra3C8rf+KP4Zn2gDqz3JxX930Ft0CdSnAqbaO5P8tRxlF/caMmDvqoc/uuihEHgf5V9PeGW6DsC2+QxxlXPE4byPc6854KYu4VXVoR0/MurFkLRGATQBZXnJIBvHQnrZdei3olw==,iv:QYvgZRWZGD4qDBrnEtyks4sg70PRwm6EQM6VcwJN5b8=,tag:XrmCacyb9Ol+6GXLpaqgKA==,type:comment]
+ADGUARD_REDIS_PASSWORD=ENC[AES256_GCM,data:h6vBJUTgEXFy0eflBKrKvoj+zb2a8a/WTEfyXrbVhzHUDb9wOiwl//M9yA==,iv:tGPSCtV7iVUZUgLEUYNc9tbP0R95SJBcO2VElswKoks=,tag:ctnuBKdJ8auXz7xOUdKvPQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNUEdsYWtFZUFELzhZdVlH\nWmZyNFJqVGtrSlJRN0tkV3hHN1k5STN2QXo4Cm01bmZGZ09uUTA2a1RpZmhZaFJn\nMFB2M0JTVHdzVTNiajJGUnR3NDRDREEKLS0tIDEycVkzQzJ2YkNQRHU2L1pObVFl\nOUdHbUhKVjhOZ1g2YkVrMXJZMTlFdWcKcm3egimQP5+HwuUo/qdZ9XPCz7KVuyEg\nWk6FMSUa7hgMQO9O+OCLI9JkcMIxjzqk4IOxAUHl8YocK/EJpQaNBw==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_0__map_recipient=age18mdfujf864x66ys9slshhzknnq5argngyhu55zqenccjdf9fd3lqgpyp6n
-sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBYQ3dxL3JmY2xFbnlHUzll\naVhoWTBEMTZ1dXp1SVhEU05xVTVMRVFacWxNCkorWEJycmxTY1pMTDB3VjFXbjdP\nTmZPRTY4ajhCK2RFazM5K1V3MnlDeG8KLS0tIG5BbzhLN01xSmtOcjBzZDNWUDhr\nbjBmaldWS0JwUjNiTzVXWkJkVS85bmMKCzUXjwW+6NH46BGeIVhLaa1cvb+lrr1Y\ndY6qSrJRRKJ4xLIVop0r9mjOpT2qGBRIJsq0xMHXReHFLKr1AERfzw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB5YzJxSUs1Q2htdkpqbmdI\nSzFLL0h5RnNydnBlVWhqd0ZBVFNNVzFud2xBClNmYUl1bHlNQnI1Ymg0MjJTUmlS\nVTBSeWpMZjZTTDZVcC9TczF1aHdQL3MKLS0tIEEvVWxHd2pnN1M3bWxzTXRRMFVq\nT1g3N1FXODFwbjFRb0EyV0xwMlkxNHMKczNIJ9FcFeZHhXoFt5R/Ez7QxzYIez9b\nm+cQ2DMbPN/IDmRKxOsqJR4bbevui06QQIEp1S2qmF8QFczG8/xp9Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1dgw6l56j4qu7jnh06n9z7rpctgar3stk8hnxq3es9j88yqjpzdvqkrp7en
-sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBVUjJ6Q1dxV2Z6OVNPcDBN\nd2QzQTkwN0FQMHB2ckJYSytSR2FFc1lsQWtjCk1NZnM0SzFCV3hOSFhkTjhhQUV0\nd090ZElDc3BSV1JNUHZEVVhtcCtmTW8KLS0tIElxNDNmWTQxa3lrRlZkNHdoR3Q3\nMW1lVm4rcWZQVWYvdEVjUi9jRHZ1MzgK+PVkFv0wzXeZuoE++AZXQTKVzZ2CtOmF\nbodOOx2pfEmRlmYmVk/euvsqeVWIj4xDR9vbfg88IfwyuY/xwFWAyg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpamlKVTAyMnZtVG9qL3VR\nUmFkSzZKQ29Jb2s0U1doY1Q1bDNGb3BZdWhjCmROZE96S0FEMzM2NE01NFk1aXdQ\nN3phN2lvVHJwYXFET0tTYWI2Wmg4VmsKLS0tIHViNE1GY0FHZXRobi9FQU9uRTBH\nY3EzTW5TVTIzMFNzQmtNclkvOEJKdXMKfwkKUTTKmL8wVWh2zTMePG/3DH+R/3XB\nLcdlQIfCV0Kn7BYtQjruX33jcwpqQqsGpApHhM8oITWY38hK1xth5Q==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_2__map_recipient=age1xmc30s0v8m4eng93d4lmdzvcsrhvtmm57nfgrwwjsew2nu2svgzqmgssvg
-sops_lastmodified=2026-04-21T19:37:40Z
-sops_mac=ENC[AES256_GCM,data:dYoo5Gm47+H7kt8mg7R/S2bgRuw5pvm45IlCqLgz0ty3SxtlmL0JRjWmjCCXj/m0Z1FhNIu3qarvMaZYqXgzfAV/t4icWAL6itKCl9htmP5JZxqNhXmfhi4vhYwZdZH72GjeKhA1W/vCBYIIeoYfn3IUAG953v/Q+m1jb593kE4=,iv:M4ZjrIQTYsgrH2ymc9BQaGNMwCckx0hbsY2UbQFyhio=,tag:l0FnnVrRUxDgi6rSJcGidA==,type:str]
+sops_lastmodified=2026-04-30T15:16:13Z
+sops_mac=ENC[AES256_GCM,data:o/9SjJCW6p0ZcjiXe9SFQJ45tJzpzxrCSoZDjKvHzfBeul90UerYxzv6KA9GXTcDzaPcc1CCwuxhZMASxzkjOfuu1nySYlzyFCRzFBQ5WQaijujECCZoQS5Yujk/hZ/Rt7pfzqzs9YkQWMcnQyZfRFsN0Aug/IH1iz4x2+JaYlc=,iv:7E5VsnvfeYxm13xrjoEMZPaCr3ON4k9iXcE5XA5HJa0=,tag:7InpFSgz0kRRnLf4kBWWiw==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2


### PR DESCRIPTION
Closes #189.

The `adguard-redis` instance was running without authentication — anyone with access to the `adguard-backend` network could connect on port 6379 and dump or flush the DNS cache. `outline-redis` already had `--requirepass`; this brings adguard's up to parity.

## Changes

- **`compose.yaml`** — pass `--requirepass ${ADGUARD_REDIS_PASSWORD}` to `redis-server` and update the healthcheck to use `redis-cli --no-auth-warning -a ${ADGUARD_REDIS_PASSWORD} ping` (matches `outline-redis`).
- **`config/unbound/conf.d/cachedb.conf`** — add `redis-server-password "${ADGUARD_REDIS_PASSWORD}"` directive.
- **`config/unbound/envsubst.sh`** — include `cachedb.conf` in the substitution loop and the unresolved-placeholder check, so the password is interpolated at deploy time. The compose `cachedb.conf` mount moves from `./config` (git-tracked, `:ro`) to `./data/unbound/conf.d/cachedb.conf` (envsubst output).
- **`secret.sops.env`** — add `ADGUARD_REDIS_PASSWORD` (43-char URL-safe random, SOPS-encrypted).

## Behaviour during deploy

`adguard-unbound depends_on: adguard-redis: service_healthy`, so unbound only starts after redis is up with auth wired. The new healthcheck fails fast on auth misconfiguration. No data migration needed — the redis instance is ephemeral (`--save ""`); the cache simply re-fills on first queries.

## Validation

- `docker compose -f services/adguard/compose.yaml config --quiet` — no errors (warnings only for env var defaults at lint time).
- `mise exec -- yamlfmt -lint services/adguard/compose.yaml` — clean.
- `mise exec -- shellcheck services/adguard/config/unbound/envsubst.sh` — clean.
- `sops -d services/adguard/secret.sops.env | grep ADGUARD_REDIS_PASSWORD` — present and decrypts.