### PR TITLE
feat(alloy): scrape Traefik /metrics endpoint

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -319,6 +319,28 @@ Other container attempting to use monitoring entrypoint:
 | `services/traefik/config/rules/middlewares.yml` | `monitoring-ipallowlist.ipAllowList.sourceRange` |
 | `services/traefik/config/traefik.yml`           | Comment documenting the subnet (for reference)   |
 
+### Alloy Metrics Scrape Entrypoint
+
+Alloy scrapes Traefik's Prometheus metrics over a second internal entrypoint, `metrics`, listening on port 8082. The entrypoint is **not host-published** — only containers on a Docker network Traefik joins can reach it. An entrypoint-level `metrics-ipallowlist@file` middleware further restricts source IPs to the `alloy-frontend` subnet (`172.30.100.8/29`), pinned in `services/alloy/compose.yaml`. This mirrors the Gatus monitoring-entrypoint security model (unpublished port + Docker network isolation + entrypoint-level `ipAllowList`).
+
+The `metrics.prometheus` block in `traefik.yml` enables `addRoutersLabels`, `addServicesLabels`, and `addEntryPointsLabels` so per-router, per-service, and per-entrypoint cardinality is exposed. Each Alloy instance scrapes the local Traefik instance running on the same host (works for both svlnas and svlazext, since Traefik's `compose.svlazext.yaml` already lists `alloy-frontend` in its network list).
+
+**Subnets and entrypoints in use:**
+
+| Entrypoint   | Port | Source range allowed                 | Purpose                            |
+| ------------ | ---- | ------------------------------------ | ---------------------------------- |
+| `monitoring` | 8444 | `gatus-frontend` (`172.30.100.0/29`) | Gatus auth-free health checks      |
+| `metrics`    | 8082 | `alloy-frontend` (`172.30.100.8/29`) | Alloy Prometheus scrape of Traefik |
+
+**Configuration locations (keep in sync when changing the subnet):**
+
+| File                                            | What to update                                      |
+| ----------------------------------------------- | --------------------------------------------------- |
+| `services/alloy/compose.yaml`                   | `alloy-frontend` network `ipam.config[0].subnet`    |
+| `services/traefik/config/rules/middlewares.yml` | `metrics-ipallowlist.ipAllowList.sourceRange`       |
+| `services/traefik/config/traefik.yml`           | `metrics` entrypoint address + `metrics.prometheus` |
+| `services/alloy/config/config.alloy`            | `prometheus.scrape "traefik"` target host:port      |
+
 ## Docker Socket Proxy
 
 Services never mount `/var/run/docker.sock` directly. Instead, each gets its own [LinuxServer socket-proxy](https://github.com/linuxserver/docker-socket-proxy) instance with minimal permissions:

--- a/services/alloy/README.md
+++ b/services/alloy/README.md
@@ -10,6 +10,7 @@ Alloy collapses what previously required several agents into a single process:
 
 - **Host metrics** via `prometheus.exporter.unix` (the embedded `node_exporter` library — `/proc`, `/sys`, and the rootfs are bind-mounted from the host).
 - **Container logs** via `loki.source.docker`, with a `discovery.docker` step that auto-discovers running containers and promotes compose project/service labels. Reaches the Docker socket through a read-only LinuxServer socket-proxy.
+- **Traefik metrics** via `prometheus.scrape "traefik"`, targeting the local Traefik instance at `traefik:8082/metrics` over the shared `alloy-frontend` Docker network (60s interval, `host` and `job=traefik` labels added via relabeling). Per-router, per-service, and per-entrypoint label cardinality is enabled on the Traefik side. The `:8082` entrypoint is internal-only and gated by an `ipAllowList` restricted to the pinned `alloy-frontend` subnet (`172.30.100.8/29`) — see [Architecture § Alloy Metrics Scrape Entrypoint](../ARCHITECTURE.md#alloy-metrics-scrape-entrypoint).
 - **Self-observability** via `prometheus.exporter.self`.
 
 ### Out of scope

--- a/services/alloy/compose.yaml
+++ b/services/alloy/compose.yaml
@@ -177,6 +177,12 @@ networks:
   alloy-frontend:
     name: alloy-frontend
     driver: bridge
+    # Pinned subnet so Traefik's metrics-ipallowlist middleware (in
+    # config/rules/middlewares.yml) can restrict :8082 (Prometheus metrics
+    # entrypoint) to Alloy. Mirrors the gatus-frontend pattern.
+    ipam:
+      config:
+        - subnet: 172.30.100.8/29
   alloy-backend:
     name: alloy-backend
     driver: bridge

--- a/services/alloy/config/config.alloy
+++ b/services/alloy/config/config.alloy
@@ -192,3 +192,44 @@ prometheus.relabel "alloy_self" {
 		replacement  = "alloy"
 	}
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// Traefik — scrape the Prometheus /metrics endpoint exposed on the internal
+// `metrics` entrypoint (:8082) of the local Traefik instance.
+//
+// The metrics entrypoint is unpublished (no host port mapping) and gated by
+// an entrypoint-level ipAllowList middleware (metrics-ipallowlist@file in
+// services/traefik/config/rules/middlewares.yml) restricted to the
+// alloy-frontend subnet (172.30.100.8/29). Alloy reaches Traefik via the
+// shared `alloy-frontend` Docker network (joined by both this Alloy instance
+// and the Traefik instance running on the same host).
+//
+// `addRoutersLabels`, `addServicesLabels`, and `addEntryPointsLabels` are
+// enabled in traefik.yml, so the metrics include per-router / per-service /
+// per-entrypoint cardinality. Acceptable for this lab's router count; revisit
+// if Grafana Cloud Free's active-series budget tightens.
+////////////////////////////////////////////////////////////////////////////////
+
+prometheus.scrape "traefik" {
+	targets = [
+		{ __address__ = "traefik:8082", instance = sys.env("HOSTNAME_OVERRIDE") },
+	]
+	forward_to = [prometheus.relabel.traefik.receiver]
+
+	scrape_interval = "60s"
+	scrape_timeout  = "10s"
+	metrics_path    = "/metrics"
+}
+
+prometheus.relabel "traefik" {
+	forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+
+	rule {
+		target_label = "host"
+		replacement  = sys.env("HOSTNAME_OVERRIDE")
+	}
+	rule {
+		target_label = "job"
+		replacement  = "traefik"
+	}
+}

--- a/services/traefik/README.md
+++ b/services/traefik/README.md
@@ -22,7 +22,7 @@ Exposing 20+ services to the network without a reverse proxy would mean managing
 - **Image**: [traefik](https://github.com/traefik/traefik) (official)
 - **User/Group**: `3100:3100` (`svc-app-traefik`)
 - **Networks**: Joins every service's frontend network individually for per-service isolation (see [Architecture](../ARCHITECTURE.md#networking-per-service-isolation))
-- **Ports**: `80` (HTTP → HTTPS redirect), `443` (HTTPS), `8444` (internal monitoring entrypoint — not published)
+- **Ports**: `80` (HTTP → HTTPS redirect), `443` (HTTPS), `8444` (internal monitoring entrypoint — not published), `8082` (internal metrics entrypoint — not published)
 - **Reverse proxy**: Self-proxied dashboard with `chain-auth@file` middleware
 
 ### Key Features
@@ -31,6 +31,7 @@ Exposing 20+ services to the network without a reverse proxy would mean managing
 - **Docker provider**: Auto-discovers services from Docker labels via socket proxy
 - **Per-service networks**: Each service gets its own frontend network — containers can only talk to Traefik, not to each other
 - **Monitoring entrypoint**: Port 8444 with IP allowlist restricted to the `gatus-frontend` subnet for auth-free health checks
+- **Metrics entrypoint**: Port 8082 with IP allowlist restricted to the `alloy-frontend` subnet — Prometheus scrape target for Alloy (per-router / per-service / per-entrypoint labels enabled)
 
 ### Services
 

--- a/services/traefik/config/rules/middlewares.yml
+++ b/services/traefik/config/rules/middlewares.yml
@@ -9,6 +9,14 @@ http:
       ipAllowList:
         sourceRange:
           - "172.30.100.0/29"
+    # Restricts the metrics entrypoint (:8082, Prometheus /metrics) to the
+    # alloy-frontend subnet so only Alloy can scrape Traefik metrics. Applied
+    # at the entrypoint level in traefik.yml. If the alloy-frontend IPAM
+    # subnet changes (services/alloy/compose.yaml), update sourceRange here.
+    metrics-ipallowlist:
+      ipAllowList:
+        sourceRange:
+          - "172.30.100.8/29"
     middlewares-rate-limit:
       rateLimit:
         average: 100

--- a/services/traefik/config/traefik.yml
+++ b/services/traefik/config/traefik.yml
@@ -31,9 +31,24 @@ entryPoints:
     http:
       middlewares:
         - monitoring-ipallowlist@file
+  # Internal-only entrypoint for Prometheus metrics scraping by Alloy. Not
+  # published to the host; only reachable via the alloy-frontend Docker
+  # network. An entrypoint-level ipAllowList restricts access to the
+  # alloy-frontend subnet (172.30.100.8/29) so that no other container on a
+  # frontend network Traefik joins can scrape /metrics (which exposes router,
+  # service, and entrypoint topology).
+  metrics:
+    address: ":8082"
+    http:
+      middlewares:
+        - metrics-ipallowlist@file
 
 metrics:
   prometheus:
+    entryPoint: metrics
+    addRoutersLabels: true
+    addServicesLabels: true
+    addEntryPointsLabels: true
     buckets:
       - 0.1
       - 0.3


### PR DESCRIPTION
Phase 2 of #15 — Alloy now scrapes Traefik's Prometheus metrics on a new internal-only entrypoint, gated by an `ipAllowList` restricted to the `alloy-frontend` Docker network.

## Changes

- **`services/traefik/config/traefik.yml`** — add `metrics` entrypoint on `:8082` with entrypoint-level `metrics-ipallowlist@file` middleware. Configure `metrics.prometheus.entryPoint: metrics` and enable `addRoutersLabels` / `addServicesLabels` / `addEntryPointsLabels` for per-router / service / entrypoint cardinality.
- **`services/traefik/config/rules/middlewares.yml`** — add `metrics-ipallowlist` middleware restricting source range to `172.30.100.8/29` (alloy-frontend subnet). Mirrors the existing `monitoring-ipallowlist` pattern.
- **`services/alloy/compose.yaml`** — pin `alloy-frontend` network IPAM to `subnet: 172.30.100.8/29` so the ipAllowList has a stable CIDR to match. Mirrors the `gatus-frontend: 172.30.100.0/29` pattern.
- **`services/alloy/config/config.alloy`** — add `prometheus.scrape "traefik"` job targeting `traefik:8082` over the shared `alloy-frontend` network. 60s interval, `host` + `job=traefik` relabels. Each Alloy instance scrapes its local Traefik (works on both `svlnas` and `svlazext` since `compose.svlazext.yaml` already lists `alloy-frontend` in Traefik's network list).

## Docs

- `docs/ARCHITECTURE.md` — new entrypoint / subnet table + configuration-locations table.
- `services/alloy/README.md` — Traefik scrape target added to the list.
- `services/traefik/README.md` — `:8082` metrics entrypoint added to ports + key features.

## Validation

- `docker compose config --quiet` ✓ (only expected `DOMAINNAME` warnings)
- `yamlfmt -lint` / `yamllint` / `dprint check` ✓

Refs #15