### PR TITLE
refactor(scripts): migrate utility scripts to log.sh helpers

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -447,3 +447,66 @@ Reusable env files live in `services/shared/env/` and are referenced via relativ
 | `tz.env` | Sets `TZ=Europe/Amsterdam` | Every container |
 
 UID and GID values are **not** stored in shared env files or in `secret.sops.env`. They are hardcoded directly in each service's `compose.yaml` (in the `user:` directive and init container commands) so they are visible, auditable, and not treated as secrets. See [Infrastructure § UID/GID Allocation](INFRASTRUCTURE.md#uidgid-allocation) for the full allocation table.
+
+## Shell Script Logging
+
+Utility scripts under `scripts/` source the vendored [`lib/log.sh`](https://github.com/DevSecNinja/dotfiles) library (pinned to a tagged release) for consistent, colorized, timestamped output with severity-aware routing (`INFO`/`STATE`/`RESULT`/`HINT`/`STEP` to stdout; `WARN`/`ERROR`/`FATAL` to stderr).
+
+Every script sources `lib/log.sh` and sets a `LOG_TAG` matching the script's purpose:
+
+```sh
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_SCRIPT_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="dccd"
+```
+
+### Helpers
+
+Severity helpers (pick by intent, not by colour):
+
+| Helper       | Use for                                              |
+| ------------ | ---------------------------------------------------- |
+| `log_error`  | Failures that abort the operation                    |
+| `log_warn`   | Recoverable issues, fallbacks, deprecations          |
+| `log_info`   | Neutral progress and informational messages          |
+| `log_state`  | An action that is **in progress** (e.g. "Deploying") |
+| `log_result` | A completed outcome or summary line                  |
+| `log_hint`   | Suggested next steps for the user                    |
+| `log_step`   | Numbered steps inside a wizard or multi-stage flow   |
+
+Structural helpers for visual grouping:
+
+| Helper                      | Renders                                 |
+| --------------------------- | --------------------------------------- |
+| `log_banner <title> [KIND]` | Boxed banner for major phase boundaries |
+| `log_rule [KIND] <title>`   | Titled horizontal divider               |
+| `log_sep [KIND]`            | Plain horizontal rule                   |
+
+`KIND` is one of `INFO`, `STATE`, `RESULT`, `HINT`, `STEP`, `WARN`, `ERROR` and selects the colour.
+
+### Constraints
+
+- **Functions that return data via stdout** (`printf '%s' "$value"`) must redirect any internal log calls to stderr — otherwise log lines contaminate the captured value:
+
+  ```sh
+  get_thing() {
+      log_info "looking up thing" >&2
+      printf '%s' "${value}"
+  }
+  ```
+
+- **Heredoc / grouped redirects to a file** (`{ echo …; echo …; } > FILE`) must keep using plain `echo`. Those blocks produce file content, not log output, and routing them through `log_*` would prepend timestamps and tags into the written file.
+
+- **GitHub Actions annotation scripts** (`scripts/gha-image-age-check.sh`, `scripts/gha-trivy-image-scan.sh`) intentionally use plain `echo` so that `::warning::` / `::error::` workflow commands reach the runner verbatim. Do not migrate these to `log.sh`.
+
+### Refreshing the vendored copy
+
+`scripts/lib/log.sh` is vendored from a pinned upstream release. To bump it, run:
+
+```sh
+bash scripts/update-log-sh.sh
+```
+
+The refresher script downloads the configured release, verifies the SHA-256 against `scripts/lib/log.sh.sha256`, and updates both files in place. Commit the result as a `chore` change.

--- a/scripts/check-datasets.sh
+++ b/scripts/check-datasets.sh
@@ -9,9 +9,15 @@
 
 set -euo pipefail
 
+_CHECK_DATASETS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_CHECK_DATASETS_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="check-datasets"
+
 # --- Require root ---
 if [[ "${EUID}" -ne 0 ]]; then
-    echo "ERROR: This script must be run as root (use sudo)." >&2
+    log_error "This script must be run as root (use sudo)."
     exit 1
 fi
 
@@ -41,94 +47,82 @@ collect_missing() {
 
 # --- CHECK mode ---
 if [[ "${MODE}" == "check" ]]; then
-    echo "Checking service directories under: ${SERVICES_PATH}"
-    echo ""
+    log_info "Checking service directories under: ${SERVICES_PATH}"
 
     missing=()
     collect_missing missing
 
     for name in "${missing[@]}"; do
-        echo "NO DATASET: ${name}  (${SERVICES_PATH}/${name})"
+        log_warn "NO DATASET: ${name}  (${SERVICES_PATH}/${name})"
     done
 
-    echo ""
     if [[ ${#missing[@]} -eq 0 ]]; then
-        echo "All service directories have a dedicated ZFS dataset."
+        log_result "All service directories have a dedicated ZFS dataset."
     else
-        echo "${#missing[@]} service director(y/ies) without a dedicated dataset."
-        echo ""
-        echo "Run with --fix to interactively create datasets:"
-        echo "  sudo $0 --fix ${SERVICES_PATH}"
+        log_result "${#missing[@]} service director(y/ies) without a dedicated dataset."
+        log_hint "Run with --fix to interactively create datasets:"
+        log_hint "  sudo $0 --fix ${SERVICES_PATH}"
     fi
     exit 0
 fi
 
 # --- FIX mode ---
-echo "=== ZFS Dataset Fix Wizard ==="
-echo "Services path: ${SERVICES_PATH}"
-echo ""
+log_banner "ZFS Dataset Fix Wizard"
+log_info "Services path: ${SERVICES_PATH}"
 
 missing=()
 collect_missing missing
 
 if [[ ${#missing[@]} -eq 0 ]]; then
-    echo "All service directories already have a dedicated ZFS dataset. Nothing to do."
+    log_result "All service directories already have a dedicated ZFS dataset. Nothing to do."
     exit 0
 fi
 
-echo "The following ${#missing[@]} service(s) have no dedicated dataset:"
-echo ""
+log_info "The following ${#missing[@]} service(s) have no dedicated dataset:"
 for name in "${missing[@]}"; do
-    echo "  - ${name}"
+    log_info "  - ${name}"
 done
 
-echo ""
 read -r -p "Proceed with the fix workflow? [y/N] " confirm
 if [[ "${confirm}" != [yY] ]]; then
-    echo "Aborted."
+    log_warn "Aborted."
     exit 0
 fi
 
 # --- Step 1: Stop Docker Compose projects ---
-echo ""
-echo "=== Step 1/4: Stopping Docker Compose projects ==="
+log_step "Step 1/4: Stopping Docker Compose projects"
 for name in "${missing[@]}"; do
     compose_file="${SERVICES_PATH}/${name}/compose.yaml"
     if [[ -f "${compose_file}" ]]; then
-        echo "  Stopping ${name}..."
+        log_state "Stopping ${name}..."
         docker compose -f "${compose_file}" down --timeout 30 2>&1 | sed 's/^/    /'
     else
-        echo "  Skipping ${name} (no compose.yaml found)"
+        log_warn "Skipping ${name} (no compose.yaml found)"
     fi
 done
 
 # --- Step 2: Move dirs to -tmp ---
-echo ""
-echo "=== Step 2/4: Moving directories to temporary names ==="
+log_step "Step 2/4: Moving directories to temporary names"
 for name in "${missing[@]}"; do
     src="${SERVICES_PATH}/${name}"
     dst="${SERVICES_PATH}/${name}-tmp"
-    echo "  ${name}/ -> ${name}-tmp/"
+    log_state "${name}/ -> ${name}-tmp/"
     mv "${src}" "${dst}"
 done
 
 # --- Step 3: Wait for user to create datasets ---
-echo ""
-echo "=== Step 3/4: Create datasets now ==="
-echo ""
-echo "Go to the TrueNAS UI and create a dataset for each service listed below."
-echo "The dataset mountpoint must match the original path exactly."
-echo ""
-echo "Datasets to create:"
+log_step "Step 3/4: Create datasets now"
+log_hint "Go to the TrueNAS UI and create a dataset for each service listed below."
+log_hint "The dataset mountpoint must match the original path exactly."
+log_info "Datasets to create:"
 for name in "${missing[@]}"; do
-    echo "  ${SERVICES_PATH}/${name}"
+    log_info "  ${SERVICES_PATH}/${name}"
 done
-echo ""
-echo "Press ENTER when all datasets have been created..."
-read -r
+
+read -r -p "Press ENTER when all datasets have been created..." _
 
 # Verify datasets were created
-echo "Verifying datasets..."
+log_state "Verifying datasets..."
 not_created=()
 for name in "${missing[@]}"; do
     if ! zfs list -H -o mountpoint 2>/dev/null | grep -qx "${SERVICES_PATH}/${name}"; then
@@ -137,24 +131,20 @@ for name in "${missing[@]}"; do
 done
 
 if [[ ${#not_created[@]} -gt 0 ]]; then
-    echo ""
-    echo "WARNING: The following datasets were NOT detected:"
+    log_warn "The following datasets were NOT detected:"
     for name in "${not_created[@]}"; do
-        echo "  - ${name}  (expected mountpoint: ${SERVICES_PATH}/${name})"
+        log_warn "  - ${name}  (expected mountpoint: ${SERVICES_PATH}/${name})"
     done
-    echo ""
     read -r -p "Continue anyway? Data will be moved but may not be on a dataset. [y/N] " confirm
     if [[ "${confirm}" != [yY] ]]; then
-        echo ""
-        echo "Aborted. Your data is still in the -tmp directories."
-        echo "To restore manually:  mv <name>-tmp <name>"
+        log_error "Aborted. Your data is still in the -tmp directories."
+        log_hint "To restore manually:  mv <name>-tmp <name>"
         exit 1
     fi
 fi
 
 # --- Step 4: Move contents back (including dotfiles) ---
-echo ""
-echo "=== Step 4/4: Moving contents back from temporary directories ==="
+log_step "Step 4/4: Moving contents back from temporary directories"
 for name in "${missing[@]}"; do
     src="${SERVICES_PATH}/${name}-tmp"
     dst="${SERVICES_PATH}/${name}"
@@ -162,19 +152,17 @@ for name in "${missing[@]}"; do
     # Ensure the target exists (dataset mount creates it, but just in case)
     mkdir -p "${dst}"
 
-    echo "  ${name}-tmp/ -> ${name}/"
+    log_state "${name}-tmp/ -> ${name}/"
 
     # Move all files including dotfiles; use find to handle both cases
     # without relying on shell globbing options
     find "${src}" -mindepth 1 -maxdepth 1 -exec mv -t "${dst}" {} +
 
     # Remove the now-empty temp directory
-    rmdir "${src}" 2>/dev/null || echo "    NOTE: ${name}-tmp/ not empty, leaving in place"
+    rmdir "${src}" 2>/dev/null || log_warn "${name}-tmp/ not empty, leaving in place"
 done
 
-echo ""
-echo "=== Done ==="
-echo ""
-echo "Don't forget to restart your services, e.g.:"
-echo "  cd ${SERVICES_PATH}/.."
-echo "  bash scripts/dccd.sh -a"
+log_result "Done"
+log_hint "Don't forget to restart your services, e.g.:"
+log_hint "  cd ${SERVICES_PATH}/.."
+log_hint "  bash scripts/dccd.sh -a"

--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -520,27 +520,25 @@ log_image_changes() {
         return
     fi
 
-    local sep="========================================"
-    log_info "${sep}"
-
     if [ -z "${before}" ]; then
-        log_result "${app_name}: Initial deployment:"
+        log_rule RESULT "${app_name}"
+        log_result "Initial deployment:"
         while IFS= read -r line; do
             local svc="${line%%=*}"
             local img="${line#*=}"
             log_result "${svc}: ${img}"
         done <<<"${after}"
-        log_info "${sep}"
         return
     fi
 
     if [ "${before}" = "${after}" ]; then
-        log_result "${app_name}: No updates (images unchanged)"
-        log_info "${sep}"
+        log_rule RESULT "${app_name}"
+        log_result "No updates (images unchanged)"
         return
     fi
 
-    log_result "${app_name}: Image changes detected!"
+    log_rule RESULT "${app_name}"
+    log_result "Image changes detected!"
     while IFS= read -r after_line; do
         local svc="${after_line%%=*}"
         local after_img="${after_line#*=}"
@@ -557,7 +555,6 @@ log_image_changes() {
             log_result "to:   ${after_img}"
         fi
     done <<<"${after}"
-    log_info "${sep}"
 }
 
 redeploy_truenas_apps() {
@@ -1214,8 +1211,7 @@ update_compose_files() {
     fi
 
     if [ "${SHOULD_DEPLOY}" -eq 1 ]; then
-        local sep="========================================"
-        log_info "${sep}"
+        log_banner "Deployment Summary" RESULT
         local succeeded
         succeeded=$((_DEPLOY_ATTEMPTED - _DEPLOY_ERRORS))
         if [ "${_DEPLOY_ERRORS}" -eq 0 ]; then
@@ -1231,7 +1227,6 @@ update_compose_files() {
         if [ "$((_DEPLOY_CHANGED + _DEPLOY_UNCHANGED))" -gt 0 ]; then
             log_result "${_DEPLOY_CHANGED} changed, ${_DEPLOY_UNCHANGED} unchanged"
         fi
-        log_info "${sep}"
     fi
 
     local end_time elapsed_time

--- a/scripts/encrypt-secrets.sh
+++ b/scripts/encrypt-secrets.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+_ENCRYPT_SECRETS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_ENCRYPT_SECRETS_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="encrypt-secrets"
+
 ########################################
 # Configuration
 ########################################
@@ -50,19 +56,19 @@ while [ $# -gt 0 ]; do
         usage
         ;;
     *)
-        echo "Unknown option: $1" >&2
+        log_error "Unknown option: $1"
         usage
         ;;
     esac
 done
 
 if [ -z "${BASE_DIR}" ]; then
-    echo "Error: -d <base_dir> is required" >&2
+    log_error "-d <base_dir> is required"
     usage
 fi
 
 if [ ! -d "${BASE_DIR}/services" ]; then
-    echo "Error: ${BASE_DIR}/services does not exist" >&2
+    log_error "${BASE_DIR}/services does not exist"
     exit 1
 fi
 
@@ -97,57 +103,52 @@ done
 ########################################
 
 total=$((${#encrypted_files[@]} + ${#unencrypted_files[@]}))
-echo "Found ${total} secret.sops.env file(s):"
-echo "  ✓ ${#encrypted_files[@]} encrypted"
-echo "  ✗ ${#unencrypted_files[@]} unencrypted"
-echo ""
+log_info "Found ${total} secret.sops.env file(s):"
+log_info "  ${#encrypted_files[@]} encrypted, ${#unencrypted_files[@]} unencrypted"
 
 if [ ${#unencrypted_files[@]} -eq 0 ]; then
-    echo "All secret files are encrypted."
+    log_result "All secret files are encrypted."
     exit 0
 fi
 
-echo "Unencrypted files:"
+log_warn "Unencrypted files:"
 for f in "${unencrypted_files[@]}"; do
-    echo "  ${f}"
+    log_warn "  ${f}"
 done
-echo ""
 
 ########################################
 # Encrypt (if requested)
 ########################################
 
 if [ "${DO_ENCRYPT}" -eq 0 ]; then
-    echo "Run with --encrypt to encrypt these files in-place."
-    echo "Make sure .sops.yaml creation_rules are up to date first:"
-    echo "  bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"
+    log_hint "Run with --encrypt to encrypt these files in-place."
+    log_hint "Make sure .sops.yaml creation_rules are up to date first:"
+    log_hint "  bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"
     exit 1
 fi
 
-echo "Encrypting unencrypted files..."
+log_state "Encrypting unencrypted files..."
 failed=0
 for f in "${unencrypted_files[@]}"; do
-    echo "  Encrypting: ${f}"
+    log_state "Encrypting: ${f}"
     if sops -e -i "${f}"; then
-        echo "    ✓ Done"
+        log_result "Encrypted: ${f}"
     else
-        echo "    ✗ FAILED"
+        log_error "Failed to encrypt: ${f}"
         failed=1
     fi
 done
 
-echo ""
 if [ "${failed}" -eq 1 ]; then
-    echo "Some files failed to encrypt. Check the output above."
-    echo "Common causes:"
-    echo "  - Missing .sops.yaml creation_rule for the file"
-    echo "  - No Age key available (set SOPS_AGE_KEY_FILE or SOPS_AGE_KEY)"
+    log_error "Some files failed to encrypt. Check the output above."
+    log_hint "Common causes:"
+    log_hint "  - Missing .sops.yaml creation_rule for the file"
+    log_hint "  - No Age key available (set SOPS_AGE_KEY_FILE or SOPS_AGE_KEY)"
     exit 1
 fi
 
-echo "All files encrypted successfully."
-echo ""
-echo "Next steps:"
-echo "  1. Review changes: git diff"
-echo "  2. If server-app mappings changed, regenerate SOPS rules:"
-echo "     bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"
+log_result "All files encrypted successfully."
+log_hint "Next steps:"
+log_hint "  1. Review changes: git diff"
+log_hint "  2. If server-app mappings changed, regenerate SOPS rules:"
+log_hint "     bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"

--- a/scripts/generate-docs-symlinks.sh
+++ b/scripts/generate-docs-symlinks.sh
@@ -15,6 +15,11 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${0}")/.." && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${REPO_ROOT}/scripts/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="generate-docs-symlinks"
+
 DOCS_SERVICES="${REPO_ROOT}/docs/services"
 SERVICES_DIR="${REPO_ROOT}/services"
 
@@ -23,7 +28,7 @@ mkdir -p "${DOCS_SERVICES}"
 # Remove stale symlinks (service was retired or README removed)
 find "${DOCS_SERVICES}" -maxdepth 1 -type l | while read -r link; do
     if [[ ! -e "${link}" ]]; then
-        echo "Removing stale symlink: ${link}"
+        log_state "Removing stale symlink: ${link}"
         rm "${link}"
     fi
 done
@@ -54,8 +59,8 @@ for readme in "${SERVICES_DIR}"/*/README.md; do
     fi
 
     ln -s "${target}" "${symlink}"
-    echo "Created symlink: docs/services/${service_name}.md → ${target}"
+    log_state "Created symlink: docs/services/${service_name}.md → ${target}"
     ((created++)) || true
 done
 
-echo "Done. ${created} symlink(s) created."
+log_result "${created} symlink(s) created."

--- a/scripts/generate-sops-rules.sh
+++ b/scripts/generate-sops-rules.sh
@@ -16,6 +16,12 @@
 
 set -euo pipefail
 
+_GEN_SOPS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_GEN_SOPS_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="generate-sops-rules"
+
 ########################################
 # Default configuration
 ########################################
@@ -47,11 +53,11 @@ while getopts ":d:uh" opt; do
     u) UPDATE_KEYS=1 ;;
     h) usage ;;
     \?)
-        echo "Invalid option: -${OPTARG}" >&2
+        log_error "Invalid option: -${OPTARG}"
         usage
         ;;
     :)
-        echo "Option -${OPTARG} requires an argument." >&2
+        log_error "Option -${OPTARG} requires an argument."
         usage
         ;;
     *) usage ;;
@@ -59,12 +65,12 @@ while getopts ":d:uh" opt; do
 done
 
 if [ -z "${BASE_DIR}" ]; then
-    echo "ERROR: -d is required." >&2
+    log_error "-d is required."
     usage
 fi
 
 if ! command -v yq >/dev/null 2>&1; then
-    echo "ERROR: yq is required but not found on PATH" >&2
+    log_error "yq is required but not found on PATH"
     exit 1
 fi
 
@@ -73,12 +79,12 @@ SOPS_YAML="${BASE_DIR}/.sops.yaml"
 AGE_KEY="${BASE_DIR}/age.key"
 
 if [ ! -f "${SERVERS_YAML}" ]; then
-    echo "ERROR: servers.yaml not found at ${SERVERS_YAML}" >&2
+    log_error "servers.yaml not found at ${SERVERS_YAML}"
     exit 1
 fi
 
 if [ ! -f "${AGE_KEY}" ]; then
-    echo "ERROR: age.key not found at ${AGE_KEY}" >&2
+    log_error "age.key not found at ${AGE_KEY}"
     exit 1
 fi
 
@@ -88,11 +94,11 @@ fi
 
 DEPLOY_KEY=$(grep -oP '# public key: \K(age1[a-z0-9]+)' "${AGE_KEY}") || true
 if [ -z "${DEPLOY_KEY}" ]; then
-    echo "ERROR: Could not extract public key from ${AGE_KEY}" >&2
-    echo "ERROR: Expected a line like: # public key: age1..." >&2
+    log_error "Could not extract public key from ${AGE_KEY}"
+    log_error "Expected a line like: # public key: age1..."
     exit 1
 fi
-echo "Deploy key: ${DEPLOY_KEY}"
+log_info "Deploy key: ${DEPLOY_KEY}"
 
 ########################################
 # Build app → server key mapping
@@ -106,7 +112,7 @@ local_server_list=$(yq -r '.servers | keys | .[]' "${SERVERS_YAML}") || true
 while IFS= read -r server; do
     key=$(yq -r ".servers.\"${server}\".age_public_key" "${SERVERS_YAML}")
     if [ -z "${key}" ] || [ "${key}" = "null" ]; then
-        echo "WARNING: Server '${server}' has no age_public_key set, skipping" >&2
+        log_warn "Server '${server}' has no age_public_key set, skipping"
         continue
     fi
     SERVER_KEYS["${server}"]="${key}"
@@ -115,10 +121,10 @@ while IFS= read -r server; do
     has_apps=$(yq -r ".servers.\"${server}\" | has(\"apps\")" "${SERVERS_YAML}")
     if [ "${has_apps}" != "true" ]; then
         ALL_ACCESS_KEYS+=("${key}")
-        echo "Server '${server}': all-access (no apps list)"
+        log_info "Server '${server}': all-access (no apps list)"
     else
         app_count=$(yq -r ".servers.\"${server}\".apps | length" "${SERVERS_YAML}")
-        echo "Server '${server}': ${app_count} app(s)"
+        log_info "Server '${server}': ${app_count} app(s)"
     fi
 done <<<"${local_server_list}"
 
@@ -154,7 +160,7 @@ for server_sops_file in "${BASE_DIR}"/services/*/secret.*.sops.env; do
     fi
     app_name=$(basename "$(dirname "${server_sops_file}")")
     HAS_SERVER_SECRETS["${app_name}:${server_name}"]="1"
-    echo "  Per-server secret: ${app_name}/secret.${server_name}.sops.env"
+    log_info "Per-server secret: ${app_name}/secret.${server_name}.sops.env"
 done
 
 for sops_file in "${BASE_DIR}"/services/*/secret.sops.env; do
@@ -200,7 +206,7 @@ for server_sops_file in "${BASE_DIR}"/services/*/secret.*.sops.env; do
 
     server_key="${SERVER_KEYS[${server_name}]:-}"
     if [ -z "${server_key}" ]; then
-        echo "WARNING: Server '${server_name}' in filename ${server_basename} not found in servers.yaml, skipping" >&2
+        log_warn "Server '${server_name}' in filename ${server_basename} not found in servers.yaml, skipping"
         continue
     fi
 
@@ -269,8 +275,7 @@ FALLBACK_KEYS=$(echo "${BASE_KEYS}" | tr ',' '\n' | sort -u | paste -sd',')
 } >"${SOPS_YAML}"
 
 rule_count=$(grep -c 'path_regex:' "${SOPS_YAML}") || true
-echo ""
-echo "Generated ${SOPS_YAML} with ${rule_count} rule(s)"
+log_result "Generated ${SOPS_YAML} with ${rule_count} rule(s)"
 
 ########################################
 # Update keys on existing encrypted files
@@ -278,12 +283,11 @@ echo "Generated ${SOPS_YAML} with ${rule_count} rule(s)"
 
 if [ "${UPDATE_KEYS}" -eq 1 ]; then
     if ! command -v sops >/dev/null 2>&1; then
-        echo "ERROR: sops is required for -u but not found on PATH" >&2
+        log_error "sops is required for -u but not found on PATH"
         exit 1
     fi
 
-    echo ""
-    echo "Updating keys on all secret files..."
+    log_state "Updating keys on all secret files..."
     update_count=0
     update_errors=0
 
@@ -291,27 +295,25 @@ if [ "${UPDATE_KEYS}" -eq 1 ]; then
         "${BASE_DIR}"/services/*/secret*.sops.env \
         "${BASE_DIR}"/services/shared/*/secret*.sops.env; do
         [ -f "${sops_file}" ] || continue
-        echo "  Updating: ${sops_file}"
+        log_state "Updating: ${sops_file}"
         if sops updatekeys -y "${sops_file}"; then
             update_count=$((update_count + 1))
         else
-            echo "  WARNING: Failed to update keys for ${sops_file}" >&2
+            log_warn "Failed to update keys for ${sops_file}"
             update_errors=$((update_errors + 1))
         fi
     done
 
-    echo ""
     if [ "${update_errors}" -eq 0 ]; then
-        echo "Updated keys on ${update_count} file(s)"
+        log_result "Updated keys on ${update_count} file(s)"
     else
-        echo "Updated keys on ${update_count} file(s), ${update_errors} failed"
+        log_result "Updated keys on ${update_count} file(s), ${update_errors} failed"
     fi
 else
-    echo ""
-    echo "Next steps:"
-    echo "  1. Review the generated .sops.yaml"
-    echo "  2. Run '$0 -d ${BASE_DIR} -u' or 'sops updatekeys' on each secret file"
-    echo "  3. For new per-server files, create them plaintext then encrypt:"
-    echo "     sops -e -i services/<app>/secret.<server>.sops.env"
-    echo "  4. Commit the updated .sops.yaml and re-encrypted secret files"
+    log_hint "Next steps:"
+    log_hint "  1. Review the generated .sops.yaml"
+    log_hint "  2. Run '$0 -d ${BASE_DIR} -u' or 'sops updatekeys' on each secret file"
+    log_hint "  3. For new per-server files, create them plaintext then encrypt:"
+    log_hint "     sops -e -i services/<app>/secret.<server>.sops.env"
+    log_hint "  4. Commit the updated .sops.yaml and re-encrypted secret files"
 fi


### PR DESCRIPTION
Migrates the remaining utility scripts to the vendored `log.sh` helpers introduced in #264, and cleans up `dccd.sh` to use structural helpers (`log_banner`, `log_rule`) instead of manually-printed `====` separators.

## Migrated scripts

- `scripts/check-datasets.sh` — wizard now uses `log_banner`, `log_step`, `log_state`, `log_hint`, `log_warn`, `log_error`, `log_result`. Interactive `read -r -p` prompts retained as plain `read` (no log timestamps on prompts).
- `scripts/encrypt-secrets.sh` — diagnostics migrated to `log_error` / `log_info` / `log_warn` / `log_state` / `log_result` / `log_hint`. Removed ✓/✗ glyphs in favour of the severity prefix.
- `scripts/generate-sops-rules.sh` — diagnostics migrated to `log_error` / `log_warn` / `log_info` / `log_state` / `log_result` / `log_hint`. The redirected `{ echo "---"; … } > "${SOPS_YAML}"` block is intentionally left untouched (it generates file content, not log output).
- `scripts/generate-docs-symlinks.sh` — `log_state` for stale/created symlink notices, `log_result` for the final summary.

## Cleanup in `dccd.sh`

- `log_image_changes` — replaced `local sep="===…"` plus surrounding `log_info "${sep}"` calls with a single `log_rule RESULT "${app_name}"` per app. Drops the redundant `${app_name}:` prefix from each `log_result` line since the rule already shows it.
- Final deployment summary — replaced the manual separator + log_info pair with `log_banner "Deployment Summary" RESULT`.

## Validation

- `mise exec -- shellcheck` — clean for all five scripts.
- `mise exec -- shfmt --diff` — clean for all five scripts.
- `mise exec -- bats tests/dccd/unit tests/dccd/integration` — 166/166 pass.
- `mise exec -- lefthook run pre-commit` — all hooks green (shfmt, shellcheck, gitleaks, trivy, checkov, bats).

## Out of scope

- `scripts/gha-image-age-check.sh` and `scripts/gha-trivy-image-scan.sh` deliberately skipped — they emit GitHub Actions `::warning::` / `::error::` annotations that are best left as-is.
- Documentation update will follow in a separate task (Technical Writer agent).