### PR TITLE
refactor(dccd): use 'pull --quiet' in TrueNAS path to silence per-image lines

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -658,7 +658,7 @@ redeploy_truenas_apps() {
                 "${COMPOSE_PROFILE_ARGS[@]}" \
                 --project-name "${project_name}" \
                 --file "${compose_file}" \
-                pull
+                pull --quiet
         else
             log_state "Skipping image pull for ${app_name} (no-pull mode)"
         fi


### PR DESCRIPTION
The non-TrueNAS deploy path already runs `docker compose ... pull --quiet`, but the TrueNAS path in `redeploy_truenas_apps` was still calling plain `pull`, which produces the noisy

```
[+] Pulling 6/6
 ✔ adguard-unbound-init Skipped - Image is already being pulled by adguard-init
 ✔ adguard-unbound Pulled
 …
```

block on every app, every run. Since `dccd-all` already prints a per-app `Pulling images for <app>` `STATE` line and `log_image_changes` reports the actual outcome via `log_rule` + `log_result`, those raw progress lines add no useful information and break up the otherwise clean log.

Add `--quiet` to bring the TrueNAS path in line with the non-TrueNAS path. Errors are still surfaced (`pull --quiet` only suppresses progress, not warnings/errors).