### PR TITLE
refactor(dccd): pipe docker compose pull output through log helpers

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -91,6 +91,27 @@ flush_output_buffer() {
 # Non-root execution: always use sudo for docker commands
 SUDO="sudo"
 
+# log_pipe — read stdin line-by-line and re-emit each non-empty line through
+# log.sh so external command output (e.g. `docker compose pull` progress) is
+# rendered with the same timestamp/severity/tag prefix as the rest of the log.
+# Strips ANSI escape sequences and trailing whitespace for clean output.
+# Usage: <command> 2>&1 | log_pipe [KIND]
+#   KIND defaults to INFO; pass STATE for in-progress action lines.
+log_pipe() {
+    local kind="${1:-INFO}"
+    local line
+    while IFS= read -r line; do
+        # Strip ANSI escapes and CRs that docker compose emits for progress redraws
+        line=$(printf '%s' "${line}" | sed -E $'s/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\r//g; s/[[:space:]]+$//')
+        [ -z "${line}" ] && continue
+        case "${kind}" in
+        STATE) log_state "${line}" ;;
+        WARN) log_warn "${line}" ;;
+        *) log_info "${line}" ;;
+        esac
+    done
+}
+
 ensure_sops() {
     mkdir -p "${SOPS_INSTALL_DIR}"
     local sops_bin="${SOPS_INSTALL_DIR}/sops-${SOPS_VERSION}"
@@ -654,11 +675,15 @@ redeploy_truenas_apps() {
         # Pull images (unless NO_PULL is set)
         if [ "${NO_PULL}" -eq 0 ]; then
             log_state "Pulling images for ${app_name}"
-            ${SUDO} docker compose \
+            # Pipe pull output through log_pipe so each `[+] Pulling …` /
+            # `✔ service Pulled` line is timestamped and tagged like the rest
+            # of the log. pipefail (set at the top of the script) propagates a
+            # non-zero exit from docker compose through the pipe.
+            ${SUDO} docker compose --progress=plain \
                 "${COMPOSE_PROFILE_ARGS[@]}" \
                 --project-name "${project_name}" \
                 --file "${compose_file}" \
-                pull --quiet
+                pull 2>&1 | log_pipe
         else
             log_state "Skipping image pull for ${app_name} (no-pull mode)"
         fi
@@ -886,7 +911,7 @@ redeploy_compose_file() {
 
     # Pull images unless NO_PULL is set
     if [ "${NO_PULL}" -eq 0 ]; then
-        run_compose_command "${compose_file_args[@]}" pull --quiet
+        run_compose_command --progress=plain "${compose_file_args[@]}" pull 2>&1 | log_pipe
     else
         log_state "Skipping image pull for ${file} (no-pull mode)"
     fi


### PR DESCRIPTION
Follow-up to #266. The previous PR fully silenced the per-image pull lines with `pull --quiet`. Visibility is preferable: those lines confirm progress and surface registry errors. The fix is to keep the output but render each line through `log.sh` so it matches the rest of the log instead of breaking the format.

## Before (#266 + plain pull)

```
2026-04-30 21:14:55 STATE  [dccd] Pulling images for adguard
[+] Pulling 6/6
 ✔ adguard-redis Pulled                                                    0.3s
 ✔ adguard-unbound Pulled                                                  0.4s
 …
2026-04-30 21:14:57 STATE  [dccd] Starting containers for adguard
```

## After

```
2026-04-30 21:14:55 STATE  [dccd] Pulling images for adguard
2026-04-30 21:14:55 INFO   [dccd] [+] Pulling 6/6
2026-04-30 21:14:55 INFO   [dccd]  ✔ adguard-redis Pulled                  0.3s
2026-04-30 21:14:55 INFO   [dccd]  ✔ adguard-unbound Pulled                0.4s
…
2026-04-30 21:14:57 STATE  [dccd] Starting containers for adguard
```

## Implementation

- Add a small `log_pipe [KIND]` helper near the top of `dccd.sh` that reads stdin line-by-line, strips ANSI escapes / CRs / trailing whitespace, and re-emits each non-empty line via `log_info` (default), `log_state`, or `log_warn`.
- Replace `pull --quiet` with `--progress=plain pull 2>&1 | log_pipe` in both the TrueNAS path (`redeploy_truenas_apps`) and the generic path (`redeploy_compose_file`).
- `--progress=plain` ensures docker compose emits one line per service event instead of redrawing in place — important because the pipe is non-TTY so escape sequences would otherwise pile up.

`set -o pipefail` (already in effect at the top of the script) propagates a non-zero exit from `docker compose pull` through the pipe, so errors still abort the deploy as before.

## Validation

- `mise exec -- shellcheck scripts/dccd.sh` — clean.
- `mise exec -- shfmt --diff scripts/dccd.sh` — clean.
- `mise exec -- bats tests/dccd/unit tests/dccd/integration` — 166/166 pass.
- Smoke-tested `log_pipe` with both plain and ANSI-coloured input; output matches the example above with escapes stripped.