### PR TITLE
refactor(dccd): use log_data for docker compose pull output

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -91,27 +91,6 @@ flush_output_buffer() {
 # Non-root execution: always use sudo for docker commands
 SUDO="sudo"
 
-# log_pipe — read stdin line-by-line and re-emit each non-empty line through
-# log.sh so external command output (e.g. `docker compose pull` progress) is
-# rendered with the same timestamp/severity/tag prefix as the rest of the log.
-# Strips ANSI escape sequences and trailing whitespace for clean output.
-# Usage: <command> 2>&1 | log_pipe [KIND]
-#   KIND defaults to INFO; pass STATE for in-progress action lines.
-log_pipe() {
-    local kind="${1:-INFO}"
-    local line
-    while IFS= read -r line; do
-        # Strip ANSI escapes and CRs that docker compose emits for progress redraws
-        line=$(printf '%s' "${line}" | sed -E $'s/\x1b\[[0-9;?]*[a-zA-Z]//g; s/\r//g; s/[[:space:]]+$//')
-        [ -z "${line}" ] && continue
-        case "${kind}" in
-        STATE) log_state "${line}" ;;
-        WARN) log_warn "${line}" ;;
-        *) log_info "${line}" ;;
-        esac
-    done
-}
-
 ensure_sops() {
     mkdir -p "${SOPS_INSTALL_DIR}"
     local sops_bin="${SOPS_INSTALL_DIR}/sops-${SOPS_VERSION}"
@@ -674,16 +653,16 @@ redeploy_truenas_apps() {
 
         # Pull images (unless NO_PULL is set)
         if [ "${NO_PULL}" -eq 0 ]; then
-            log_state "Pulling images for ${app_name}"
-            # Pipe pull output through log_pipe so each `[+] Pulling …` /
-            # `✔ service Pulled` line is timestamped and tagged like the rest
-            # of the log. pipefail (set at the top of the script) propagates a
-            # non-zero exit from docker compose through the pipe.
+            # Pipe pull output through log_data so the per-image progress lines
+            # render as continuation entries (│ prefix) under a single header,
+            # using the standard log.sh timestamp/INFO/[dccd] formatting.
+            # pipefail (set at the top of the script) propagates a non-zero exit
+            # from docker compose through the pipe.
             ${SUDO} docker compose --progress=plain \
                 "${COMPOSE_PROFILE_ARGS[@]}" \
                 --project-name "${project_name}" \
                 --file "${compose_file}" \
-                pull 2>&1 | log_pipe
+                pull 2>&1 | log_data INFO "Pulling images for ${app_name}"
         else
             log_state "Skipping image pull for ${app_name} (no-pull mode)"
         fi
@@ -911,7 +890,8 @@ redeploy_compose_file() {
 
     # Pull images unless NO_PULL is set
     if [ "${NO_PULL}" -eq 0 ]; then
-        run_compose_command --progress=plain "${compose_file_args[@]}" pull 2>&1 | log_pipe
+        run_compose_command --progress=plain "${compose_file_args[@]}" pull 2>&1 |
+            log_data INFO "Pulling images for ${app_name}"
     else
         log_state "Skipping image pull for ${file} (no-pull mode)"
     fi


### PR DESCRIPTION
## Summary

Replace the bespoke `log_pipe` helper introduced in #267 with the standard `log.sh` `log_data` primitive. `log_data` was already part of the upstream library and renders one header line plus `│ <line>` continuation entries for each line of stdin — exactly the wrapping we want for noisy subcommand output. Net `-20` LOC.

## Before / After

Before (#267, custom `log_pipe`):
```
2026-04-30 19:30:01 INFO   [dccd] Pulling images for adguard
2026-04-30 19:30:01 INFO   [dccd] [+] Pulling 6/6
2026-04-30 19:30:02 INFO   [dccd]  ✔ adguard-redis Pulled                          0.3s
2026-04-30 19:30:02 INFO   [dccd]  ✔ adguard Pulled                                0.4s
```

After (this PR, `log_data`):
```
2026-04-30 19:36:02 INFO   [dccd] Pulling images for adguard
2026-04-30 19:36:02 INFO   [dccd] │ [+] Pulling 6/6
2026-04-30 19:36:02 INFO   [dccd] │  ✔ adguard-redis Pulled                          0.3s
2026-04-30 19:36:02 INFO   [dccd] │  ✔ adguard Pulled                                0.4s
```

The `│ ` prefix visually groups the wrapped output and makes it obvious where the subcommand block starts and ends. A single timestamp is shared across the block.

## Changes

- Remove the local `log_pipe` helper (~20 lines) — it was reinventing `log_data`.
- Pipe both `docker compose … pull` invocations (TrueNAS path + generic path) through `log_data INFO "Pulling images for ${app_name}"`.

## Verification

- `mise exec -- shellcheck scripts/dccd.sh` — clean
- `mise exec -- shfmt --diff scripts/dccd.sh` — clean
- `mise exec -- bats tests/dccd/unit tests/dccd/integration` — 166/166 pass
- Smoke test of `log_data` rendering confirmed expected `│ ` continuation prefix
