### PR TITLE
refactor(scripts): adopt log.sh helpers consistently across all scripts

### DIFF
--- a/scripts/check-datasets.sh
+++ b/scripts/check-datasets.sh
@@ -52,9 +52,10 @@ if [[ "${MODE}" == "check" ]]; then
     missing=()
     collect_missing missing
 
-    for name in "${missing[@]}"; do
-        log_warn "NO DATASET: ${name}  (${SERVICES_PATH}/${name})"
-    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        printf '%s\n' "${missing[@]}" |
+            log_data WARN "Service directories without a dedicated ZFS dataset"
+    fi
 
     if [[ ${#missing[@]} -eq 0 ]]; then
         log_result "All service directories have a dedicated ZFS dataset."
@@ -78,10 +79,8 @@ if [[ ${#missing[@]} -eq 0 ]]; then
     exit 0
 fi
 
-log_info "The following ${#missing[@]} service(s) have no dedicated dataset:"
-for name in "${missing[@]}"; do
-    log_info "  - ${name}"
-done
+printf '%s\n' "${missing[@]}" |
+    log_data INFO "The following ${#missing[@]} service(s) have no dedicated dataset"
 
 read -r -p "Proceed with the fix workflow? [y/N] " confirm
 if [[ "${confirm}" != [yY] ]]; then
@@ -94,8 +93,8 @@ log_step "Step 1/4: Stopping Docker Compose projects"
 for name in "${missing[@]}"; do
     compose_file="${SERVICES_PATH}/${name}/compose.yaml"
     if [[ -f "${compose_file}" ]]; then
-        log_state "Stopping ${name}..."
-        docker compose -f "${compose_file}" down --timeout 30 2>&1 | sed 's/^/    /'
+        docker compose -f "${compose_file}" down --timeout 30 2>&1 |
+            log_data STATE "Stopping ${name}"
     else
         log_warn "Skipping ${name} (no compose.yaml found)"
     fi
@@ -114,15 +113,14 @@ done
 log_step "Step 3/4: Create datasets now"
 log_hint "Go to the TrueNAS UI and create a dataset for each service listed below."
 log_hint "The dataset mountpoint must match the original path exactly."
-log_info "Datasets to create:"
 for name in "${missing[@]}"; do
-    log_info "  ${SERVICES_PATH}/${name}"
-done
+    printf '%s/%s\n' "${SERVICES_PATH}" "${name}"
+done | log_data INFO "Datasets to create"
 
 read -r -p "Press ENTER when all datasets have been created..." _
 
 # Verify datasets were created
-log_state "Verifying datasets..."
+log_state "Verifying datasets"
 not_created=()
 for name in "${missing[@]}"; do
     if ! zfs list -H -o mountpoint 2>/dev/null | grep -qx "${SERVICES_PATH}/${name}"; then
@@ -131,10 +129,9 @@ for name in "${missing[@]}"; do
 done
 
 if [[ ${#not_created[@]} -gt 0 ]]; then
-    log_warn "The following datasets were NOT detected:"
     for name in "${not_created[@]}"; do
-        log_warn "  - ${name}  (expected mountpoint: ${SERVICES_PATH}/${name})"
-    done
+        printf -- '- %s  (expected mountpoint: %s/%s)\n' "${name}" "${SERVICES_PATH}" "${name}"
+    done | log_data WARN "The following datasets were NOT detected"
     read -r -p "Continue anyway? Data will be moved but may not be on a dataset. [y/N] " confirm
     if [[ "${confirm}" != [yY] ]]; then
         log_error "Aborted. Your data is still in the -tmp directories."

--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -583,7 +583,7 @@ redeploy_truenas_apps() {
 
         # If EXCLUDE is set and the app matches, skip it
         if [ -n "${EXCLUDE}" ] && [[ "${app_name}" == *"${EXCLUDE}"* ]]; then
-            log_state "Skipping excluded app '${app_name}'"
+            log_info "Skipping excluded app '${app_name}'"
             continue
         fi
 
@@ -664,7 +664,7 @@ redeploy_truenas_apps() {
                 --file "${compose_file}" \
                 pull 2>&1 | log_data INFO "Pulling images for ${app_name}"
         else
-            log_state "Skipping image pull for ${app_name} (no-pull mode)"
+            log_info "Skipping image pull for ${app_name} (no-pull mode)"
         fi
 
         # Deploy
@@ -893,7 +893,7 @@ redeploy_compose_file() {
         run_compose_command --progress=plain "${compose_file_args[@]}" pull 2>&1 |
             log_data INFO "Pulling images for ${app_name}"
     else
-        log_state "Skipping image pull for ${file} (no-pull mode)"
+        log_info "Skipping image pull for ${file} (no-pull mode)"
     fi
 
     if [ "${GRACEFUL}" -eq 1 ]; then
@@ -985,13 +985,13 @@ update_compose_files() {
         current_user=$(whoami) || true
         bad_git_files=$(find "${dir}/.git" -maxdepth 2 ! -user "$(id -u)" -print 2>/dev/null) || true
         if [ -n "${bad_git_files}" ]; then
-            log_error ".git/ contains files not owned by the current user (${current_user}):"
             local file_owner
             while IFS= read -r f; do
                 file_owner=$(stat -c '%U' "${f}" 2>/dev/null) || file_owner="unknown"
-                log_error "${f}  (owner: ${file_owner})"
-            done <<<"${bad_git_files}"
-            log_error "Fix with: sudo chown -R ${current_user} ${dir}/.git"
+                printf '%s  (owner: %s)\n' "${f}" "${file_owner}"
+            done <<<"${bad_git_files}" |
+                log_data ERROR ".git/ contains files not owned by the current user (${current_user})"
+            log_hint "Fix with: sudo chown -R ${current_user} ${dir}/.git"
             exit 1
         fi
 
@@ -1004,12 +1004,12 @@ update_compose_files() {
             xargs -0 -I{} find "${dir}/{}" -maxdepth 0 ! -user "$(id -u)" -print 2>/dev/null |
             grep -v '/data/' | grep -v '/backups/') || true
         if [ -n "${bad_tracked_files}" ]; then
-            log_error "Git-tracked files not owned by the current user (${current_user}):"
             while IFS= read -r f; do
                 file_owner=$(stat -c '%U(%u)' "${f}" 2>/dev/null) || file_owner="unknown"
-                log_error "${f}  (owner: ${file_owner})"
-            done <<<"${bad_tracked_files}"
-            log_error "git pull will fail. Fix with: sudo chown -R ${current_user} <affected-dirs>"
+                printf '%s  (owner: %s)\n' "${f}" "${file_owner}"
+            done <<<"${bad_tracked_files}" |
+                log_data ERROR "Git-tracked files not owned by the current user (${current_user})"
+            log_hint "git pull will fail. Fix with: sudo chown -R ${current_user} <affected-dirs>"
             exit 1
         fi
 
@@ -1205,14 +1205,12 @@ update_compose_files() {
     local root_owned
     root_owned=$(find "${BASE_DIR}" \( -name data -o -name backups \) -prune -o -user root -print 2>/dev/null) || true
     if [ -n "${root_owned}" ]; then
-        log_warn "Files owned by root detected (git fetch/pull or SOPS may have created them):"
-        while IFS= read -r f; do
-            log_warn "${f}"
-        done <<<"${root_owned}"
+        printf '%s\n' "${root_owned}" |
+            log_data WARN "Files owned by root detected (git fetch/pull or SOPS may have created them)"
         local current_user
         current_user=$(whoami) || true
-        log_warn "To fix, run manually:"
-        log_warn "find \"${BASE_DIR}\" \\( -name data -o -name backups \\) -prune -o -user root -print0 | xargs -0 -r sudo chown ${current_user}:${current_user}"
+        log_hint "To fix, run manually:"
+        log_hint "find \"${BASE_DIR}\" \\( -name data -o -name backups \\) -prune -o -user root -print0 | xargs -0 -r sudo chown ${current_user}:${current_user}"
     fi
 
     if [ "${SHOULD_DEPLOY}" -eq 1 ]; then
@@ -1222,11 +1220,10 @@ update_compose_files() {
         if [ "${_DEPLOY_ERRORS}" -eq 0 ]; then
             log_result "All ${_DEPLOY_ATTEMPTED} app(s) deployed successfully"
         else
-            log_result "${succeeded}/${_DEPLOY_ATTEMPTED} app(s) deployed successfully, ${_DEPLOY_ERRORS} failed:"
+            log_result "${succeeded}/${_DEPLOY_ATTEMPTED} app(s) deployed successfully, ${_DEPLOY_ERRORS} failed"
             if [ "${#_DEPLOY_FAILED_APPS[@]}" -gt 0 ]; then
-                for app in "${_DEPLOY_FAILED_APPS[@]}"; do
-                    log_result "FAILED: ${app}"
-                done
+                printf '%s\n' "${_DEPLOY_FAILED_APPS[@]}" |
+                    log_data ERROR "Failed apps"
             fi
         fi
         if [ "$((_DEPLOY_CHANGED + _DEPLOY_UNCHANGED))" -gt 0 ]; then
@@ -1237,9 +1234,9 @@ update_compose_files() {
     local end_time elapsed_time
     end_time=$(date +%s)
     elapsed_time=$((end_time - _CD_START_TIME))
-    log_info "Total execution time: ${elapsed_time}s"
+    log_kv duration_seconds="${elapsed_time}"
 
-    log_state "Done!"
+    log_result "Done"
 }
 
 # Simple URL encoding for query string values (handles spaces and common special chars)

--- a/scripts/encrypt-secrets.sh
+++ b/scripts/encrypt-secrets.sh
@@ -103,27 +103,26 @@ done
 ########################################
 
 total=$((${#encrypted_files[@]} + ${#unencrypted_files[@]}))
-log_info "Found ${total} secret.sops.env file(s):"
-log_info "  ${#encrypted_files[@]} encrypted, ${#unencrypted_files[@]} unencrypted"
+log_kv total="${total}" encrypted="${#encrypted_files[@]}" unencrypted="${#unencrypted_files[@]}"
 
 if [ ${#unencrypted_files[@]} -eq 0 ]; then
     log_result "All secret files are encrypted."
     exit 0
 fi
 
-log_warn "Unencrypted files:"
-for f in "${unencrypted_files[@]}"; do
-    log_warn "  ${f}"
-done
+printf '%s\n' "${unencrypted_files[@]}" |
+    log_data WARN "Unencrypted files"
 
 ########################################
 # Encrypt (if requested)
 ########################################
 
 if [ "${DO_ENCRYPT}" -eq 0 ]; then
-    log_hint "Run with --encrypt to encrypt these files in-place."
-    log_hint "Make sure .sops.yaml creation_rules are up to date first:"
-    log_hint "  bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"
+    printf '%s\n' \
+        "Run with --encrypt to encrypt these files in-place." \
+        "Make sure .sops.yaml creation_rules are up to date first:" \
+        "  bash scripts/generate-sops-rules.sh -d ${BASE_DIR}" |
+        log_data HINT "To fix"
     exit 1
 fi
 
@@ -141,14 +140,16 @@ done
 
 if [ "${failed}" -eq 1 ]; then
     log_error "Some files failed to encrypt. Check the output above."
-    log_hint "Common causes:"
-    log_hint "  - Missing .sops.yaml creation_rule for the file"
-    log_hint "  - No Age key available (set SOPS_AGE_KEY_FILE or SOPS_AGE_KEY)"
+    printf '%s\n' \
+        "Missing .sops.yaml creation_rule for the file" \
+        "No Age key available (set SOPS_AGE_KEY_FILE or SOPS_AGE_KEY)" |
+        log_data HINT "Common causes"
     exit 1
 fi
 
 log_result "All files encrypted successfully."
-log_hint "Next steps:"
-log_hint "  1. Review changes: git diff"
-log_hint "  2. If server-app mappings changed, regenerate SOPS rules:"
-log_hint "     bash scripts/generate-sops-rules.sh -d ${BASE_DIR}"
+printf '%s\n' \
+    "1. Review changes: git diff" \
+    "2. If server-app mappings changed, regenerate SOPS rules:" \
+    "   bash scripts/generate-sops-rules.sh -d ${BASE_DIR}" |
+    log_data HINT "Next steps"

--- a/scripts/generate-sops-rules.sh
+++ b/scripts/generate-sops-rules.sh
@@ -310,10 +310,11 @@ if [ "${UPDATE_KEYS}" -eq 1 ]; then
         log_result "Updated keys on ${update_count} file(s), ${update_errors} failed"
     fi
 else
-    log_hint "Next steps:"
-    log_hint "  1. Review the generated .sops.yaml"
-    log_hint "  2. Run '$0 -d ${BASE_DIR} -u' or 'sops updatekeys' on each secret file"
-    log_hint "  3. For new per-server files, create them plaintext then encrypt:"
-    log_hint "     sops -e -i services/<app>/secret.<server>.sops.env"
-    log_hint "  4. Commit the updated .sops.yaml and re-encrypted secret files"
+    printf '%s\n' \
+        "1. Review the generated .sops.yaml" \
+        "2. Run '$0 -d ${BASE_DIR} -u' or 'sops updatekeys' on each secret file" \
+        "3. For new per-server files, create them plaintext then encrypt:" \
+        "     sops -e -i services/<app>/secret.<server>.sops.env" \
+        "4. Commit the updated .sops.yaml and re-encrypted secret files" |
+        log_data HINT "Next steps"
 fi

--- a/scripts/gha-backup-restore-test.sh
+++ b/scripts/gha-backup-restore-test.sh
@@ -91,7 +91,7 @@ wait_for_postgres() {
     local container="$1"
     local attempts=0
     local max=30
-    log_info "Waiting for PostgreSQL in ${container} to become ready..."
+    log_state "Waiting for PostgreSQL in ${container} to become ready"
     until docker exec "${container}" pg_isready -U "${DB_USER}" -d "${DB_NAME}" >/dev/null 2>&1; do
         attempts=$((attempts + 1))
         [ "${attempts}" -ge "${max}" ] && die "${container} did not become ready after ${max} attempts"
@@ -104,7 +104,7 @@ wait_for_mongo() {
     local container="$1"
     local attempts=0
     local max=30
-    log_info "Waiting for MongoDB in ${container} to become ready..."
+    log_state "Waiting for MongoDB in ${container} to become ready"
     # mongosh is shipped in the official mongo image. Authenticate against the
     # admin DB to be sure user provisioning has finished, not just the daemon.
     until docker exec "${container}" mongosh \
@@ -134,19 +134,19 @@ decrypt_and_decompress() {
 
     # NOTE: this function returns the dump path on stdout, so all log output
     # must go to stderr to avoid polluting the captured value.
-    log_info "Decrypting ${enc_file} with gpg..." >&2
+    log_state "Decrypting ${enc_file} with gpg" >&2
     gpg --batch --passphrase "${ENC_PASSPHRASE}" \
         --output "${compressed}" --decrypt "${enc_file}" >/dev/null 2>&1
 
     case "${compressed}" in
     *.zst)
         dump_file="${compressed%.zst}"
-        log_info "Decompressing ${compressed} with zstd..." >&2
+        log_state "Decompressing ${compressed} with zstd" >&2
         zstd -df "${compressed}" -o "${dump_file}" >/dev/null
         ;;
     *.gz)
         dump_file="${compressed%.gz}"
-        log_info "Decompressing ${compressed} with gzip..." >&2
+        log_state "Decompressing ${compressed} with gzip" >&2
         gunzip -c "${compressed}" >"${dump_file}"
         ;;
     *)
@@ -174,12 +174,12 @@ find_backup_file() {
 # --- Scenario 1: PostgreSQL --------------------------------------------------
 
 run_postgres_scenario() {
-    log_info "=== PostgreSQL backup/restore cycle ==="
+    log_rule STATE "PostgreSQL backup/restore cycle"
 
     local backup_dir="${WORK_DIR}/pgsql"
     mkdir -p "${backup_dir}"
 
-    log_info "Starting source PostgreSQL (${PG_SOURCE})..."
+    log_state "Starting source PostgreSQL (${PG_SOURCE})"
     docker run -d \
         --name "${PG_SOURCE}" \
         --network "${NETWORK}" \
@@ -190,14 +190,14 @@ run_postgres_scenario() {
 
     wait_for_postgres "${PG_SOURCE}"
 
-    log_info "Inserting sentinel row..."
+    log_state "Inserting sentinel row"
     docker exec -i -e PGPASSWORD="${DB_PASS}" "${PG_SOURCE}" psql \
         -U "${DB_USER}" -d "${DB_NAME}" >/dev/null <<SQL
 CREATE TABLE restore_sentinel (id SERIAL PRIMARY KEY, value TEXT NOT NULL);
 INSERT INTO restore_sentinel (value) VALUES ('${SENTINEL}');
 SQL
 
-    log_info "Running tiredofit/db-backup (pgsql)..."
+    log_state "Running tiredofit/db-backup (pgsql)"
     docker run --rm \
         --network "${NETWORK}" \
         -e USER_DBBACKUP="${HOST_UID}" \
@@ -228,13 +228,13 @@ SQL
     dump_file="$(decrypt_and_decompress "${enc_file}")"
     log_info "Dump ready: ${dump_file}"
 
-    log_info "Verifying plain-text pg_dump structure..."
+    log_state "Verifying plain-text pg_dump structure"
     grep -q '^-- PostgreSQL database dump' "${dump_file}" ||
         die "dump file does not contain the expected PostgreSQL dump header"
     grep -q 'restore_sentinel' "${dump_file}" ||
         die "dump file does not reference the expected sentinel table"
 
-    log_info "Starting restore-target PostgreSQL (${PG_RESTORE})..."
+    log_state "Starting restore-target PostgreSQL (${PG_RESTORE})"
     docker run -d \
         --name "${PG_RESTORE}" \
         --network "${NETWORK}" \
@@ -245,14 +245,14 @@ SQL
 
     wait_for_postgres "${PG_RESTORE}"
 
-    log_info "Restoring dump with psql..."
+    log_state "Restoring dump with psql"
     docker cp "${dump_file}" "${PG_RESTORE}:/tmp/restore.sql"
     docker exec -e PGPASSWORD="${DB_PASS}" "${PG_RESTORE}" psql \
         -U "${DB_USER}" -d "${DB_NAME}" \
         --set ON_ERROR_STOP=on \
         -f /tmp/restore.sql >/dev/null
 
-    log_info "Verifying sentinel row in restored database..."
+    log_state "Verifying sentinel row in restored database"
     local restored
     restored=$(docker exec -e PGPASSWORD="${DB_PASS}" "${PG_RESTORE}" psql \
         -U "${DB_USER}" -d "${DB_NAME}" -t -A -c \
@@ -262,18 +262,18 @@ SQL
 
     docker rm -f "${PG_SOURCE}" "${PG_RESTORE}" >/dev/null 2>&1 || true
 
-    log_info "PostgreSQL scenario PASSED"
+    log_result "PostgreSQL scenario PASSED"
 }
 
 # --- Scenario 2: MongoDB -----------------------------------------------------
 
 run_mongo_scenario() {
-    log_info "=== MongoDB backup/restore cycle ==="
+    log_rule STATE "MongoDB backup/restore cycle"
 
     local backup_dir="${WORK_DIR}/mongo"
     mkdir -p "${backup_dir}"
 
-    log_info "Starting source MongoDB (${MONGO_SOURCE})..."
+    log_state "Starting source MongoDB (${MONGO_SOURCE})"
     docker run -d \
         --name "${MONGO_SOURCE}" \
         --network "${NETWORK}" \
@@ -283,7 +283,7 @@ run_mongo_scenario() {
 
     wait_for_mongo "${MONGO_SOURCE}"
 
-    log_info "Inserting sentinel document..."
+    log_state "Inserting sentinel document"
     docker exec -i "${MONGO_SOURCE}" mongosh \
         --quiet \
         --username "${DB_USER}" \
@@ -293,7 +293,7 @@ run_mongo_scenario() {
 db.restore_sentinel.insertOne({ value: "${SENTINEL}" });
 JS
 
-    log_info "Running tiredofit/db-backup (mongo)..."
+    log_state "Running tiredofit/db-backup (mongo)"
     docker run --rm \
         --network "${NETWORK}" \
         -e USER_DBBACKUP="${HOST_UID}" \
@@ -325,7 +325,7 @@ JS
     dump_file="$(decrypt_and_decompress "${enc_file}")"
     log_info "Dump ready: ${dump_file}"
 
-    log_info "Verifying mongodump archive header..."
+    log_state "Verifying mongodump archive header"
     # mongodump --archive files start with the magic bytes "8199e26d" (LE) per
     # the BSON archive format spec. Check the magic to ensure the file is a
     # well-formed mongodump archive and not a partial / corrupt download.
@@ -334,7 +334,7 @@ JS
     [ "${magic}" = "6de29981" ] ||
         die "dump file does not have a valid mongodump archive header (got '${magic}')"
 
-    log_info "Starting restore-target MongoDB (${MONGO_RESTORE})..."
+    log_state "Starting restore-target MongoDB (${MONGO_RESTORE})"
     docker run -d \
         --name "${MONGO_RESTORE}" \
         --network "${NETWORK}" \
@@ -344,7 +344,7 @@ JS
 
     wait_for_mongo "${MONGO_RESTORE}"
 
-    log_info "Restoring dump with mongorestore..."
+    log_state "Restoring dump with mongorestore"
     docker cp "${dump_file}" "${MONGO_RESTORE}:/tmp/restore.archive"
     docker exec "${MONGO_RESTORE}" mongorestore \
         --username "${DB_USER}" \
@@ -353,7 +353,7 @@ JS
         --drop \
         --archive=/tmp/restore.archive >/dev/null 2>&1
 
-    log_info "Verifying sentinel document in restored database..."
+    log_state "Verifying sentinel document in restored database"
     local restored
     restored=$(docker exec "${MONGO_RESTORE}" mongosh \
         --quiet \
@@ -368,13 +368,13 @@ JS
 
     docker rm -f "${MONGO_SOURCE}" "${MONGO_RESTORE}" >/dev/null 2>&1 || true
 
-    log_info "MongoDB scenario PASSED"
+    log_result "MongoDB scenario PASSED"
 }
 
 # --- Scenario 3: SQLite ------------------------------------------------------
 
 run_sqlite_scenario() {
-    log_info "=== SQLite backup/restore cycle ==="
+    log_rule STATE "SQLite backup/restore cycle"
 
     local src_dir="${WORK_DIR}/sqlite_src"
     local backup_dir="${WORK_DIR}/sqlite_backup"
@@ -382,13 +382,13 @@ run_sqlite_scenario() {
     mkdir -p "${src_dir}" "${backup_dir}" "${restore_dir}"
 
     local src_db="${src_dir}/${DB_NAME}.db"
-    log_info "Creating source SQLite database with sentinel..."
+    log_state "Creating source SQLite database with sentinel"
     sqlite3 "${src_db}" <<SQL
 CREATE TABLE restore_sentinel (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL);
 INSERT INTO restore_sentinel (value) VALUES ('${SENTINEL}');
 SQL
 
-    log_info "Running tiredofit/db-backup (sqlite3)..."
+    log_state "Running tiredofit/db-backup (sqlite3)"
     # SQLite doesn't need a server; mount the db read-only into the backup
     # container, mirroring the home-assistant compose setup.
     docker run --rm \
@@ -418,7 +418,7 @@ SQL
     dump_file="$(decrypt_and_decompress "${enc_file}")"
     log_info "Dump ready: ${dump_file}"
 
-    log_info "Verifying SQLite backup magic bytes..."
+    log_state "Verifying SQLite backup magic bytes"
     # tiredofit/db-backup for sqlite3 uses the SQLite Online Backup API
     # (sqlite3 .backup), producing a *binary* SQLite database file — not a
     # plain-text .dump. Validate by checking the SQLite file magic header
@@ -428,7 +428,7 @@ SQL
     [ "${magic}" = "SQLite format 3" ] ||
         die "dump file does not have a valid SQLite database header"
 
-    log_info "Restoring dump into a fresh SQLite database..."
+    log_state "Restoring dump into a fresh SQLite database"
     local restore_db="${restore_dir}/${DB_NAME}.db"
     cp "${dump_file}" "${restore_db}"
     # Sanity-check the copied file with PRAGMA integrity_check.
@@ -437,23 +437,23 @@ SQL
     [ "${integrity}" = "ok" ] ||
         die "restored SQLite db failed integrity_check (got '${integrity}')"
 
-    log_info "Verifying sentinel row in restored database..."
+    log_state "Verifying sentinel row in restored database"
     local restored
     restored=$(sqlite3 "${restore_db}" \
         "SELECT COUNT(*) FROM restore_sentinel WHERE value = '${SENTINEL}';")
     [ "${restored}" = "1" ] ||
         die "SQLite sentinel mismatch after restore (expected 1, got '${restored}')"
 
-    log_info "SQLite scenario PASSED"
+    log_result "SQLite scenario PASSED"
 }
 
 # --- Run all scenarios -------------------------------------------------------
 
-log_state "Creating Docker test network..."
+log_state "Creating Docker test network"
 docker network create "${NETWORK}" >/dev/null
 
 run_postgres_scenario
 run_mongo_scenario
 run_sqlite_scenario
 
-log_result "full backup/restore cycle passed for pgsql, mongo, and sqlite3"
+log_banner "Backup/restore cycle PASSED for pgsql, mongo, and sqlite3" RESULT

--- a/scripts/gha-image-age-check.sh
+++ b/scripts/gha-image-age-check.sh
@@ -17,6 +17,12 @@
 
 set -euo pipefail
 
+_IMG_AGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_IMG_AGE_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="image-age-check"
+
 STALE=()
 
 # get_age_days IMAGE
@@ -100,24 +106,24 @@ get_age_days() {
 while IFS= read -r full_image; do
     # Strip @sha256:... to get the name:tag for display (keep the version)
     bare="${full_image%%@*}"
-    echo "Checking ${bare}..."
+    log_state "Checking ${bare}"
 
     age_days=$(get_age_days "${bare}")
     if [ -z "${age_days}" ]; then
-        echo "  WARN: could not determine push date for ${bare}, skipping"
+        log_warn "Could not determine push date for ${bare}, skipping"
         continue
     fi
 
     if [ "${age_days}" = "skip" ]; then
-        echo "  SKIP: ${bare} has a zero-time placeholder timestamp (reproducible build image)"
+        log_info "${bare} has a zero-time placeholder timestamp (reproducible build image) — skipping"
         continue
     fi
 
     if [ "${age_days}" -gt "${THRESHOLD_DAYS}" ]; then
-        echo "  STALE: ${bare} (${age_days} days old)"
+        log_warn "STALE: ${bare} (${age_days} days old)"
         STALE+=("${full_image}")
     else
-        echo "  OK:    ${bare} (${age_days} days old)"
+        log_info "OK: ${bare} (${age_days} days old)"
     fi
 done < <(
     grep -rh 'image:' services/*/compose.yaml |
@@ -130,13 +136,10 @@ done < <(
 # --- Open new issues for freshly discovered stale images ---------------------
 
 if [ "${#STALE[@]}" -eq 0 ]; then
-    echo "All images are within the ${THRESHOLD_DAYS}-day threshold."
+    log_result "All images are within the ${THRESHOLD_DAYS}-day threshold"
 else
-    printf '\nStale images detected: %d\n' "${#STALE[@]}"
-    for image in "${STALE[@]}"; do
-        echo "  - ${image}"
-    done
-    echo ""
+    printf '%s\n' "${STALE[@]}" |
+        log_data WARN "Stale images detected: ${#STALE[@]}"
 
     for image in "${STALE[@]}"; do
         # Strip digest for the issue title so it stays readable
@@ -166,9 +169,9 @@ else
 ${sources}
 
 Please update the image digest to a more recent version to reduce exposure to known security vulnerabilities. If Renovate is not auto-updating this image, check whether the registry exposes reliable timestamp metadata."
-            echo "Created issue: ${title}"
+            log_result "Created issue: ${title}"
         else
-            echo "Still stale, issue already open: ${title}"
+            log_info "Still stale, issue already open: ${title}"
         fi
     done
 fi
@@ -178,7 +181,7 @@ fi
 # compose files. If the image is now fresh (or has been removed entirely),
 # close the issue automatically.
 
-printf '\nChecking open stale-dependency issues for resolution...\n'
+log_rule STATE "Checking open stale-dependency issues for resolution"
 
 # shellcheck disable=SC2312
 while IFS= read -r issue_json; do
@@ -189,7 +192,7 @@ while IFS= read -r issue_json; do
     case "${issue_title}" in
     *"] Stale image detected") ;;
     *)
-        echo "  SKIP: issue #${issue_number} does not match expected title format"
+        log_info "Issue #${issue_number} does not match expected title format — skipping"
         continue
         ;;
     esac
@@ -207,7 +210,7 @@ while IFS= read -r issue_json; do
         grep -F "${title_image}@" | head -1 || true)
 
     if [ -z "${current_full}" ]; then
-        echo "  ${title_image}: no longer in any compose file — closing issue #${issue_number}"
+        log_result "${title_image}: no longer in any compose file — closing issue #${issue_number}"
         gh issue close "${issue_number}" \
             --comment "This image is no longer referenced in any compose file. Closing automatically."
         continue
@@ -216,21 +219,21 @@ while IFS= read -r issue_json; do
     current_bare="${current_full%%@*}"
     age_days=$(get_age_days "${current_bare}")
     if [ -z "${age_days}" ]; then
-        echo "  WARN: could not re-check age for ${current_bare}, skipping issue #${issue_number}"
+        log_warn "Could not re-check age for ${current_bare}, skipping issue #${issue_number}"
         continue
     fi
 
     if [ "${age_days}" = "skip" ]; then
-        echo "  SKIP: ${current_bare} has a placeholder timestamp — skipping issue #${issue_number}"
+        log_info "${current_bare} has a placeholder timestamp — skipping issue #${issue_number}"
         continue
     fi
 
     if [ "${age_days}" -le "${THRESHOLD_DAYS}" ]; then
-        echo "  RESOLVED: ${current_bare} is now ${age_days} days old — closing issue #${issue_number}"
+        log_result "${current_bare} is now ${age_days} days old — closing issue #${issue_number}"
         gh issue close "${issue_number}" \
             --comment "The image \`${current_bare}\` is no longer stale (${age_days} days old, threshold: ${THRESHOLD_DAYS} days). Closing automatically."
     else
-        echo "  STILL STALE: ${current_bare} (${age_days} days old) — issue #${issue_number} remains open"
+        log_info "STILL STALE: ${current_bare} (${age_days} days old) — issue #${issue_number} remains open"
     fi
 done < <(
     gh issue list \

--- a/scripts/gha-trivy-image-scan.sh
+++ b/scripts/gha-trivy-image-scan.sh
@@ -11,6 +11,12 @@
 
 set -euo pipefail
 
+_TRIVY_SCAN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/log.sh disable=SC1091
+. "${_TRIVY_SCAN_DIR}/lib/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="trivy-image-scan"
+
 # sarif-tmp/ holds the per-image working files; sarif-output/ holds only the
 # final merged trivy-images.sarif that the workflow uploads.
 mkdir -p sarif-tmp sarif-output
@@ -21,7 +27,7 @@ mkdir -p sarif-tmp sarif-output
 while IFS= read -r full_image; do
     slug=$(echo "${full_image}" | tr '/:@' '_' | tr -cd '[:alnum:]_-')
     outfile="sarif-tmp/${slug}.sarif"
-    echo "Scanning ${full_image}..."
+    log_state "Scanning ${full_image}"
     if mise exec -- trivy image \
         --scanners vuln \
         --ignore-unfixed \
@@ -32,11 +38,11 @@ while IFS= read -r full_image; do
         # Validate that the output is parseable SARIF before keeping it.
         # Trivy may write a partial/empty file on non-fatal errors.
         if ! jq -e '.runs[0]' "${outfile}" >/dev/null 2>&1; then
-            echo "  WARN: ${outfile} is not valid SARIF, discarding"
+            log_warn "${outfile} is not valid SARIF, discarding"
             rm -f "${outfile}"
         fi
     else
-        echo "  WARN: trivy scan failed for ${full_image}, skipping"
+        log_warn "trivy scan failed for ${full_image}, skipping"
         rm -f "${outfile}"
     fi
 done < <(
@@ -52,7 +58,7 @@ done < <(
 mapfile -t sarif_files < <(find sarif-tmp -name '*.sarif' | sort)
 
 if [ "${#sarif_files[@]}" -eq 0 ]; then
-    echo "No valid SARIF files produced — all scans skipped or failed."
+    log_warn "No valid SARIF files produced — all scans skipped or failed"
     # Emit a minimal valid empty SARIF so the upload-sarif action does not error.
     # SC2016: $schema is a JSON key, not a shell variable — single quotes are correct.
     # shellcheck disable=SC2016
@@ -78,4 +84,5 @@ else
 
     # Remove the per-image working files; sarif-output/ now has only trivy-images.sarif.
     rm -rf sarif-tmp
+    log_result "Merged ${#sarif_files[@]} SARIF file(s) into sarif-output/trivy-images.sarif"
 fi

--- a/scripts/update-log-sh.sh
+++ b/scripts/update-log-sh.sh
@@ -17,11 +17,17 @@ LOG_SH_SHA_URL="https://github.com/DevSecNinja/dotfiles/releases/download/v0.1.2
 DEST_DIR="$(cd "$(dirname "$0")" && pwd)/lib"
 mkdir -p "${DEST_DIR}"
 
-echo "Fetching ${LOG_SH_URL}"
+# Source log.sh from the existing vendored copy (refreshed below).
+# shellcheck source=lib/log.sh disable=SC1091
+. "${DEST_DIR}/log.sh"
+# shellcheck disable=SC2034
+LOG_TAG="update-log-sh"
+
+log_state "Fetching ${LOG_SH_URL}"
 curl -fsSL -o "${DEST_DIR}/log.sh" "${LOG_SH_URL}"
 curl -fsSL -o "${DEST_DIR}/log.sh.sha256" "${LOG_SH_SHA_URL}"
 
-echo "Verifying checksum..."
+log_state "Verifying checksum"
 (cd "${DEST_DIR}" && sha256sum -c log.sh.sha256)
 
-echo "log.sh installed at ${DEST_DIR}/log.sh"
+log_result "log.sh installed at ${DEST_DIR}/log.sh"


### PR DESCRIPTION
## Summary

After landing `log_data` in `dccd.sh` (#268) and clarifying the upstream docs in [DevSecNinja/dotfiles#239](https://github.com/DevSecNinja/dotfiles/pull/239), this PR sweeps the rest of the shell scripts so every script uses `log.sh` helpers idiomatically. The two main improvements applied repo-wide:

1. **Per-line emit loops → `log_data`.** Anywhere a script looped over a list and emitted one log line per item, it now pipes the list through `log_data <KIND> "header"` so the items render as `│ <line>` continuation entries under a single timestamped header. Cuts log volume and groups related lines visually.
2. **Severity / kind cleanup.** `log_state` is now reserved for "currently doing X" (action in progress); facts use `log_info`; outcomes use `log_result`; multi-item suggestions use `log_data HINT`. Phase headers in the GHA backup/restore test use `log_rule STATE` instead of `=== X ===`.

## Per-script changes

### `gha-image-age-check.sh` — full migration to `log.sh`
Was using bare `echo`. Now sources `log.sh` (tag `image-age-check`) and:
- `log_state "Checking ${bare}"` for in-progress checks
- `log_warn "STALE: …"` for stale images, `log_info "OK: …"` for fresh, `log_info` for skipped placeholder timestamps
- `log_result "Created issue: …"` / `log_result "${current_bare} is now N days old — closing issue …"`
- `log_rule STATE "Checking open stale-dependency issues for resolution"` for the second phase
- The full stale-image list is now one `log_data WARN "Stale images detected: N"` block

### `gha-trivy-image-scan.sh` — full migration to `log.sh`
Sources `log.sh` (tag `trivy-image-scan`); `log_state` for "Scanning …", `log_warn` for invalid SARIF / failed scans, `log_result` for the final merged-SARIF summary.

### `gha-backup-restore-test.sh`
- `log_info "=== PostgreSQL backup/restore cycle ==="` → `log_rule STATE "PostgreSQL backup/restore cycle"` (and same for Mongo & SQLite)
- All in-progress messages (`Starting source X`, `Inserting sentinel`, `Running tiredofit/db-backup`, `Verifying …`, `Restoring …`, `Decrypting …`, `Decompressing …`, `Waiting for …`) → `log_state`
- `log_info "X scenario PASSED"` → `log_result`
- Final `log_result "full backup/restore cycle passed for …"` → `log_banner "Backup/restore cycle PASSED for pgsql, mongo, and sqlite3" RESULT`

### `dccd.sh`
- `.git/` ownership-error file list, git-tracked-ownership file list, and root-owned file list — each was a `while read; do log_error/log_warn "${f}"; done` loop. All three now pipe through `log_data ERROR/WARN "<header>"`, so an N-file problem is one timestamped block instead of N+2 separately-timestamped lines.
- Failed-app summary list (the `for app in _DEPLOY_FAILED_APPS; do log_result "FAILED: ${app}"` loop) → `log_data ERROR "Failed apps"`.
- `log_state "Skipping excluded app …"` / `log_state "Skipping image pull …"` (×2) → `log_info` (skipping is a fact, not an action in progress).
- Final `log_state "Done!"` → `log_result "Done"`.
- `log_info "Total execution time: ${elapsed_time}s"` → `log_kv duration_seconds="${elapsed_time}"` so the deploy time is parseable telemetry.
- `log_error` calls that were really fix-instructions (e.g. `Fix with: sudo chown -R …`) → `log_hint` so they render in magenta.

### `check-datasets.sh`
- "NO DATASET: …" loop in `--check` mode → `log_data WARN "Service directories without a dedicated ZFS dataset"`.
- "Datasets to create:" + per-name `log_info` loop → `log_data INFO "Datasets to create"`.
- "The following datasets were NOT detected:" + per-name `log_warn` loop → `log_data WARN "The following datasets were NOT detected"`.
- `log_state "Stopping ${name}…"` followed by `docker compose -f … down 2>&1 | sed 's/^/    /'` → `docker compose -f … down 2>&1 | log_data STATE "Stopping ${name}"` so the compose output is properly grouped with `│ ` prefix instead of indented with `sed`.

### `encrypt-secrets.sh`
- "Found N secret files: X encrypted, Y unencrypted" → `log_kv total=N encrypted=X unencrypted=Y`.
- "Unencrypted files:" + `log_warn` per file → `log_data WARN "Unencrypted files"`.
- "Common causes:" + 2× `log_hint` → `log_data HINT "Common causes"`.
- "Next steps:" + 3× `log_hint` (for `--check` and after success) → `log_data HINT "Next steps"` / `log_data HINT "To fix"`.

### `generate-sops-rules.sh`
- "Next steps:" + 5× `log_hint` → `log_data HINT "Next steps"`.

### `update-log-sh.sh`
- Bare `echo` → sources the freshly-vendored `log.sh` and uses `log_state`/`log_result`. Tag: `update-log-sh`.

## Verification

- `mise exec -- shellcheck scripts/*.sh` — clean
- `mise exec -- shfmt --diff scripts/*.sh` — clean
- `mise exec -- lefthook run pre-commit` — every check ✔ (shellcheck, shfmt, dprint, yamlfmt, yamllint, gitleaks, trivy, checkov, BATS 99/99 staged)
- `mise exec -- bats tests/dccd/unit tests/dccd/integration` — 166/166 pass
- Smoke-tested both `log_data WARN` (file-list grouping) and `log_data HINT` (multi-line next-steps) — render as expected with `│ ` continuation prefix and a single shared timestamp.

No functional change. Same exit codes, same control flow, same output content — only nicer rendering and more accurate severity/kind selection.