### PR TITLE
feat(dccd): show human-readable duration in deployment summary

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -1231,12 +1231,33 @@ update_compose_files() {
         fi
     fi
 
-    local end_time elapsed_time
+    local end_time elapsed_time human_duration
     end_time=$(date +%s)
     elapsed_time=$((end_time - _CD_START_TIME))
-    log_kv duration_seconds="${elapsed_time}"
+    human_duration=$(format_duration "${elapsed_time}")
+    if [ "${SHOULD_DEPLOY}" -eq 1 ]; then
+        log_result "Duration: ${human_duration}"
+    else
+        log_kv duration_seconds="${elapsed_time}" duration="${human_duration}"
+    fi
 
     log_result "Done"
+}
+
+# Format a duration in seconds as a human-readable string, e.g. "45s", "1m 33s",
+# "2h 5m 10s", "1d 2h 3m 4s". Always includes seconds for sub-minute precision.
+format_duration() {
+    local total="${1:-0}"
+    local days hours minutes seconds out=""
+    days=$((total / 86400))
+    hours=$(((total % 86400) / 3600))
+    minutes=$(((total % 3600) / 60))
+    seconds=$((total % 60))
+    [ "${days}" -gt 0 ] && out="${out}${days}d "
+    [ "${hours}" -gt 0 ] && out="${out}${hours}h "
+    [ "${minutes}" -gt 0 ] && out="${out}${minutes}m "
+    out="${out}${seconds}s"
+    printf '%s' "${out}"
 }
 
 # Simple URL encoding for query string values (handles spaces and common special chars)

--- a/tests/dccd/unit/format_duration.bats
+++ b/tests/dccd/unit/format_duration.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+# Unit tests for format_duration()
+
+setup() {
+    load '../helpers/common'
+    load '../helpers/mocks'
+    common_setup
+    create_default_mocks
+}
+
+teardown() {
+    common_teardown
+}
+
+@test "format_duration: zero seconds" {
+    run format_duration 0
+    assert_output "0s"
+}
+
+@test "format_duration: sub-minute" {
+    run format_duration 45
+    assert_output "45s"
+}
+
+@test "format_duration: exactly one minute" {
+    run format_duration 60
+    assert_output "1m 0s"
+}
+
+@test "format_duration: minutes and seconds" {
+    run format_duration 93
+    assert_output "1m 33s"
+}
+
+@test "format_duration: exactly one hour" {
+    run format_duration 3600
+    assert_output "1h 0m 0s"
+}
+
+@test "format_duration: hours, minutes, seconds" {
+    run format_duration 7510
+    assert_output "2h 5m 10s"
+}
+
+@test "format_duration: exactly one day" {
+    run format_duration 86400
+    assert_output "1d 0h 0m 0s"
+}
+
+@test "format_duration: days, hours, minutes, seconds" {
+    run format_duration 93784
+    assert_output "1d 2h 3m 4s"
+}
+
+@test "format_duration: skips zero hours when minutes present" {
+    run format_duration 120
+    assert_output "2m 0s"
+}
+
+@test "format_duration: defaults to 0 when arg missing" {
+    run format_duration
+    assert_output "0s"
+}


### PR DESCRIPTION
Makes the deployment summary easier to scan at the bottom of cron emails.

## Changes

- New `format_duration` helper converts seconds to a friendly string: `45s`, `1m 33s`, `2h 5m 10s`, `1d 2h 3m 4s`.
- In deploy mode, the final summary now ends with:

  ```
  All 31 app(s) deployed successfully
  0 changed, 31 unchanged
  Duration: 1m 33s
  Done
  ```

  So the success line and duration sit right next to each other at the bottom of the email.
- In non-deploy modes (decrypt-only, retire, etc.), the structured `log_kv` line emits both the raw seconds and the formatted duration: `duration_seconds=93 duration="1m 33s"` — keeping log parsers happy while still being readable.