### PR TITLE
fix(immich,outline): silence postgres-exporter config warning

### DIFF
--- a/services/immich/compose.yaml
+++ b/services/immich/compose.yaml
@@ -305,6 +305,12 @@ services:
       - path: ../shared/env/tz.env
     environment:
       - DATA_SOURCE_NAME=postgresql://immich:${IMMICH_DB_PASSWORD}@immich-db:5432/immich?sslmode=disable
+    # Point --config.file at /dev/null (always present in the container's /dev,
+    # parses as empty YAML) so the exporter does not log a startup warning
+    # about the missing optional auth_modules config. This deployment uses a
+    # single DATA_SOURCE_NAME, so no auth_modules config is needed.
+    command:
+      - --config.file=/dev/null
     user: "65534:65534" # nobody:nogroup
     deploy:
       restart_policy:

--- a/services/outline/compose.yaml
+++ b/services/outline/compose.yaml
@@ -349,6 +349,12 @@ services:
       - path: ../shared/env/tz.env
     environment:
       - DATA_SOURCE_NAME=postgresql://outline:${OUTLINE_DB_PASSWORD}@outline-db:5432/outline?sslmode=disable
+    # Point --config.file at /dev/null (always present in the container's /dev,
+    # parses as empty YAML) so the exporter does not log a startup warning
+    # about the missing optional auth_modules config. This deployment uses a
+    # single DATA_SOURCE_NAME, so no auth_modules config is needed.
+    command:
+      - --config.file=/dev/null
     user: "65534:65534" # nobody:nogroup
     deploy:
       restart_policy:


### PR DESCRIPTION
Follow-up to #284. The newly-deployed `immich-db-exporter` and `outline-db-exporter` sidecars log a startup `WARN` on every restart:

```
level=WARN source=main.go:76 msg="Error loading config"
  err="error opening config file \"postgres_exporter.yml\": open postgres_exporter.yml: no such file or directory"
```

## Why this happens

`postgres_exporter`'s `--config.file` flag defaults to the relative path `postgres_exporter.yml`. The file is **optional** — it's only used to define `auth_modules` for multi-DB scrape configurations. This deployment uses a single `DATA_SOURCE_NAME` per exporter, so no config is needed. But the binary still warns when it can't open the default path.

## Fix

Add a `command:` override that points `--config.file` at `/dev/null`:

- `/dev/null` is provided by every Linux container's runtime devtmpfs (Docker/runc set up `/dev` regardless of the base image — works fine on `FROM scratch`).
- `os.Open("/dev/null")` succeeds and returns 0 bytes.
- The YAML parser treats 0 bytes as an empty map → no `auth_modules` configured → no warning.

Applied to both `immich-db-exporter` and `outline-db-exporter`, with an inline comment explaining the rationale.

## Validation

- `yamlfmt` / `yamllint` ✓
- `docker compose -f services/immich/compose.yaml config --quiet` ✓
- `docker compose -f services/outline/compose.yaml config --quiet` ✓

Will confirm the warning is gone after deploy.

Refs #15