### PR TITLE
feat(ci): page Grafana IRM on lint.yml failure on main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -117,3 +117,57 @@ jobs:
               exit 1
             fi
           done
+
+  # --- Page on main-branch CI failure (Phase 3 of #15) ---
+  #
+  # Posts a JSON alert to a Grafana IRM webhook integration when any prior
+  # job in this workflow fails on a push to main. The step is silently
+  # skipped if the GRAFANA_IRM_WEBHOOK_URL secret is unset, so the workflow
+  # remains usable on forks and during initial repo bring-up.
+  notify-irm-on-failure:
+    name: Notify Grafana IRM on failure
+    needs:
+      - lint
+      - vendored-libs-in-sync
+      - docker-compose-config
+      - dotenv-linter
+      - validate-servers
+    if: ${{ always() && failure() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: POST failure to Grafana IRM webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_ID: ${{ github.run_id }}
+          REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          SERVER_URL: ${{ github.server_url }}
+        run: |-
+          set -euo pipefail
+          if [ -z "${WEBHOOK_URL}" ]; then
+            echo "::warning::GRAFANA_IRM_WEBHOOK_URL secret not set — skipping IRM notification."
+            exit 0
+          fi
+          run_url="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+          # Grafana IRM "Custom" webhook payload — fields map to the standard
+          # alert grouping keys; alert_uid keeps repeated runs of the same
+          # workflow on the same commit as a single incident.
+          payload=$(jq -n \
+            --arg uid "gha-${REPOSITORY}-${WORKFLOW_NAME}-${SHA}" \
+            --arg title "CI failure on main: ${WORKFLOW_NAME}" \
+            --arg state "alerting" \
+            --arg severity "critical" \
+            --arg link "${run_url}" \
+            --arg msg "Workflow '${WORKFLOW_NAME}' failed on ${REF_NAME} @ ${SHA} (actor: ${ACTOR})." \
+            '{alert_uid: $uid, title: $title, state: $state, severity: $severity, link_to_upstream_details: $link, message: $msg}')
+          curl --silent --show-error --fail-with-body \
+            --max-time 30 \
+            --request POST \
+            --header 'Content-Type: application/json' \
+            --data "${payload}" \
+            "${WEBHOOK_URL}"


### PR DESCRIPTION
Phase 3 of #15 — wires up the `if: failure()` main-branch CI pager. Adds a single `notify-irm-on-failure` job at the end of `lint.yml` that POSTs a JSON alert to a Grafana IRM webhook integration whenever any prior job in the workflow fails on a push to `main`.

## Behaviour

| Trigger                          | What happens                                                                                                |
| -------------------------------- | ----------------------------------------------------------------------------------------------------------- |
| PR run (any outcome)             | Job is **skipped** (gate: `github.event_name == 'push' && github.ref == 'refs/heads/main'`)                 |
| `push` to `main`, all jobs green | Job is **skipped** (`failure()` evaluates to false)                                                         |
| `push` to `main`, any job failed | Job runs                                                                                                    |
| Job runs, secret unset           | Step exits 0 with a workflow `::warning::` annotation — fork-safe, lands-before-IRM-exists safe             |
| Job runs, secret set             | `curl --fail-with-body --max-time 30` POSTs the payload; non-2xx response from IRM fails the job (audible) |

## Payload (Grafana IRM "Custom" webhook schema)

```json
{
  "alert_uid": "gha-DevSecNinja/truenas-apps-Lint-<sha>",
  "title": "CI failure on main: Lint",
  "state": "alerting",
  "severity": "critical",
  "link_to_upstream_details": "https://github.com/DevSecNinja/truenas-apps/actions/runs/<run_id>",
  "message": "Workflow 'Lint' failed on main @ <sha> (actor: <actor>)."
}
```

`alert_uid` is derived from `repo + workflow + SHA` so re-running the same failed workflow on the same commit groups into a single IRM incident rather than paging again.

## Security

- All `github.*` context values are passed via job-level `env:` and referenced as `$WORKFLOW_NAME`, `$RUN_ID`, etc. inside the run step. **No `${{ github.* }}` interpolation inside the run script body**, so a malicious branch / commit message / actor name cannot inject shell. zizmor passes clean.
- The webhook URL is read from `secrets.GRAFANA_IRM_WEBHOOK_URL` and only ever ends up in `curl`'s argv (not echoed to logs).
- Permissions narrowed to `contents: read` for the new job.

## Pre-merge step (one-time, in Grafana Cloud UI)

1. **IRM → Integrations → New → Webhook** (template "Custom", name `github-actions`)
2. Copy the integration URL
3. Add it as a repo secret named `GRAFANA_IRM_WEBHOOK_URL`

The PR is safe to merge before this step is done — the workflow just emits a `::warning::` and exits 0 until the secret exists.

## Validation

- `actionlint` ✓
- `zizmor` ✓ (no findings)
- `yamllint` ✓
- `yamlfmt -lint` ✓

## Scope

Initial scope is `lint.yml` only (per #15 Phase 3 sub-bullet). Once we've confirmed end-to-end that an injected failure pages, dedups correctly across re-runs, and the link opens the right run, extend the same job pattern to `image-security.yml` and `release.yml`.

Refs #15