### PR TITLE
test(ci): deliberately fail lint on push to main to verify IRM webhook

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,6 +118,23 @@ jobs:
             fi
           done
 
+  # --- TEMPORARY: deliberately fail on push to main to test the IRM
+  # failure webhook end-to-end. Revert immediately after a page is
+  # received. Tracked under #15 Phase 3 verification. The job is gated
+  # so PR runs (this very PR included) stay green and can merge cleanly;
+  # only the post-merge push-to-main run will fail.
+  trigger-irm-failure-test:
+    name: TEMPORARY — deliberate failure to test IRM webhook
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Fail on purpose
+        run: |
+          echo "::warning::Deliberate failure to verify the Grafana IRM webhook integration. Revert this job once a page has been received."
+          exit 1
+
   # --- Page on main-branch CI failure (Phase 3 of #15) ---
   #
   # Posts a JSON alert to a Grafana IRM webhook integration when any prior
@@ -132,6 +149,7 @@ jobs:
       - docker-compose-config
       - dotenv-linter
       - validate-servers
+      - trigger-irm-failure-test
     if: ${{ always() && failure() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
> [!WARNING]
> **Merge → observe page in Grafana IRM mobile app → revert immediately.** A revert PR should be opened the moment the page lands. Do not leave this job on `main` longer than the verification window.

## What this does

Adds one job to `lint.yml`:

```yaml
trigger-irm-failure-test:
  name: TEMPORARY — deliberate failure to test IRM webhook
  if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
  runs-on: ubuntu-24.04
  steps:
    - run: exit 1
```

…and adds it to `notify-irm-on-failure.needs` so the cascading failure reaches the webhook step.

## Why the PR's own CI stays green

The new job's `if:` matches the IRM-notify gate exactly: `push` event **and** `ref == refs/heads/main`. PR runs are `pull_request` events, so the failing job is **skipped** on the PR (and on subsequent feature-branch pushes). That means this PR's CI passes and can merge through normal review — the `exit 1` only fires once the merge commit lands on `main`.

## Verification flow (do this in order)

1. **Pre-check on the Grafana side**: `IRM → Integrations → github-actions` — confirm the integration is live and `GRAFANA_IRM_WEBHOOK_URL` is set as a repo secret. Without the secret the post-merge run will only emit a `::warning::` and not page (still useful to confirm the gate triggers, but no actual page).
2. **Merge this PR.**
3. Watch the **Lint** workflow run on the merge commit — `trigger-irm-failure-test` fails red, `notify-irm-on-failure` runs and POSTs to the webhook.
4. **Confirm**:
   - Page received on mobile / chosen contact channel
   - Incident shows up in IRM with `severity=critical`, `title="CI failure on main: Lint"`
   - `link_to_upstream_details` opens the failing run on this commit
   - `alert_uid` dedupes — re-running the workflow does not generate a second incident
5. **Open the revert PR immediately** (`gh pr revert <this-PR-number>` or revert via UI). Merge it after CI is green.

## Rollback

If anything misfires, just revert. The change is one isolated job — nothing else depends on it.

Refs #15