### PR TITLE
Revert "test(ci): deliberately fail lint on push to main to verify IRM webhook"

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -118,23 +118,6 @@ jobs:
             fi
           done
 
-  # --- TEMPORARY: deliberately fail on push to main to test the IRM
-  # failure webhook end-to-end. Revert immediately after a page is
-  # received. Tracked under #15 Phase 3 verification. The job is gated
-  # so PR runs (this very PR included) stay green and can merge cleanly;
-  # only the post-merge push-to-main run will fail.
-  trigger-irm-failure-test:
-    name: TEMPORARY — deliberate failure to test IRM webhook
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Fail on purpose
-        run: |
-          echo "::warning::Deliberate failure to verify the Grafana IRM webhook integration. Revert this job once a page has been received."
-          exit 1
-
   # --- Page on main-branch CI failure (Phase 3 of #15) ---
   #
   # Posts a JSON alert to a Grafana IRM webhook integration when any prior
@@ -151,7 +134,6 @@ jobs:
       - docker-compose-config
       - dotenv-linter
       - validate-servers
-      - trigger-irm-failure-test
     # Run on every completed push to main so we can fire either an
     # `alerting` (on failure) or an `ok` (on success) payload with the
     # same alert_uid. PR runs and pushes to other branches are skipped.


### PR DESCRIPTION
Reverts #302 now that the IRM webhook delivery has been verified end-to-end:

- ✅ Webhook **received** on the Grafana side (alert group registered with the correct payload — `title`, `message`, `severity=critical`, `link_to_upstream_details`, `alert_uid`)
- ⚠️ But two follow-ups that are **out of scope of #300/#302**:
  1. **No Teams page fired** — the alert group shows `Assigned escalation chain: –`. The integration was created but never wired to a chain → no contact-channel notifications. UI fix.
  2. **Alert group list shows "Incident" instead of the payload title** — IRM defaults to a generic grouping/title template. Override via the integration's grouping/title template settings to use `{{ payload.title }}` and `{{ payload.alert_uid }}`. UI fix.

Both are tracked in the next reply on #15 — neither is a code issue. The `notify-irm-on-failure` job stays in `lint.yml` and is now dormant until the next real failure on `main`.

Refs #15