### PR TITLE
feat(ci): expand IRM payload with labels + auto-resolve on green main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,11 +138,13 @@ jobs:
   # --- Page on main-branch CI failure (Phase 3 of #15) ---
   #
   # Posts a JSON alert to a Grafana IRM webhook integration when any prior
-  # job in this workflow fails on a push to main. The step is silently
-  # skipped if the GRAFANA_IRM_WEBHOOK_URL secret is unset, so the workflow
-  # remains usable on forks and during initial repo bring-up.
-  notify-irm-on-failure:
-    name: Notify Grafana IRM on failure
+  # job in this workflow fails on a push to main, OR posts a resolve when
+  # all prior jobs succeed (so a green run automatically closes the open
+  # incident from the previous failure). The step is silently skipped if
+  # the GRAFANA_IRM_WEBHOOK_URL secret is unset, so the workflow remains
+  # usable on forks and during initial repo bring-up.
+  notify-irm:
+    name: Notify Grafana IRM
     needs:
       - lint
       - vendored-libs-in-sync
@@ -150,12 +152,15 @@ jobs:
       - dotenv-linter
       - validate-servers
       - trigger-irm-failure-test
-    if: ${{ always() && failure() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    # Run on every completed push to main so we can fire either an
+    # `alerting` (on failure) or an `ok` (on success) payload with the
+    # same alert_uid. PR runs and pushes to other branches are skipped.
+    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
-      - name: POST failure to Grafana IRM webhook
+      - name: POST alert state to Grafana IRM webhook
         env:
           WEBHOOK_URL: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           WORKFLOW_NAME: ${{ github.workflow }}
@@ -165,6 +170,9 @@ jobs:
           SHA: ${{ github.sha }}
           ACTOR: ${{ github.actor }}
           SERVER_URL: ${{ github.server_url }}
+          # Whether any required job ended in failure (or was cancelled).
+          # `needs.*.result` is system-controlled, safe to interpolate.
+          JOB_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |-
           set -euo pipefail
           if [ -z "${WEBHOOK_URL}" ]; then
@@ -172,17 +180,65 @@ jobs:
             exit 0
           fi
           run_url="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
+
+          # Branch the payload by outcome.
+          # alert_uid is intentionally NOT keyed on SHA: a successful run on a
+          # later commit (different SHA) must resolve the open incident from
+          # the previous failed commit. Re-runs of the same workflow on any
+          # commit on `main` collapse into the same alert group.
+          if [ "${JOB_FAILED}" = "true" ]; then
+            state="alerting"
+            severity="critical"
+            title="CI failure on main: ${WORKFLOW_NAME}"
+            msg="Workflow '${WORKFLOW_NAME}' failed on ${REF_NAME} @ ${SHA} (actor: ${ACTOR})."
+          else
+            state="ok"
+            severity="info"
+            title="CI back to green on main: ${WORKFLOW_NAME}"
+            msg="Workflow '${WORKFLOW_NAME}' succeeded on ${REF_NAME} @ ${SHA} (actor: ${ACTOR}). Auto-resolving any open incident."
+          fi
+          echo "::notice::Posting state=${state} for ${WORKFLOW_NAME} on ${REF_NAME} @ ${SHA:0:7}"
+
           # Grafana IRM "Custom" webhook payload — fields map to the standard
-          # alert grouping keys; alert_uid keeps repeated runs of the same
-          # workflow on the same commit as a single incident.
+          # alert grouping keys. The `labels` object is the homelab convention
+          # for IRM routing/filtering — IRM surfaces it in the alert-group
+          # "Assigned labels" pane. Both `service` and `service_name` are sent
+          # because IRM uses `service_name` for SLOs/alerts/synthetic checks
+          # but `service` for incident & dashboard tags; emitting both keeps
+          # every consumer happy without an integration-side rename.
           payload=$(jq -n \
-            --arg uid "gha-${REPOSITORY}-${WORKFLOW_NAME}-${SHA}" \
-            --arg title "CI failure on main: ${WORKFLOW_NAME}" \
-            --arg state "alerting" \
-            --arg severity "critical" \
+            --arg uid "gha-${REPOSITORY}-${WORKFLOW_NAME}-${REF_NAME}" \
+            --arg title "${title}" \
+            --arg state "${state}" \
+            --arg severity "${severity}" \
             --arg link "${run_url}" \
-            --arg msg "Workflow '${WORKFLOW_NAME}' failed on ${REF_NAME} @ ${SHA} (actor: ${ACTOR})." \
-            '{alert_uid: $uid, title: $title, state: $state, severity: $severity, link_to_upstream_details: $link, message: $msg}')
+            --arg msg "${msg}" \
+            --arg service "ci" \
+            --arg source "github-actions" \
+            --arg repo "${REPOSITORY}" \
+            --arg workflow "${WORKFLOW_NAME}" \
+            --arg branch "${REF_NAME}" \
+            --arg sha_short "${SHA:0:7}" \
+            --arg actor "${ACTOR}" \
+            '{
+              alert_uid: $uid,
+              title: $title,
+              state: $state,
+              severity: $severity,
+              link_to_upstream_details: $link,
+              message: $msg,
+              labels: {
+                service: $service,
+                service_name: $service,
+                source: $source,
+                repo: $repo,
+                workflow: $workflow,
+                branch: $branch,
+                sha: $sha_short,
+                actor: $actor,
+                severity: $severity
+              }
+            }')
           curl --silent --show-error --fail-with-body \
             --max-time 30 \
             --request POST \


### PR DESCRIPTION
Builds on #300 to make the IRM webhook job actually useful as the source of truth for "is `main` CI healthy?":

1. **`labels` object on the payload** for routing/filtering/dashboards.
2. **Auto-resolve when the pipeline goes green again** — a successful push to `main` now POSTs `state: "ok"` with the same `alert_uid`, so IRM closes the open incident instead of leaving it parked until manually acknowledged.
3. **`alert_uid` no longer keys on SHA** — it used to be `gha-<repo>-<workflow>-<sha>`, which broke auto-resolve (a green run on commit B couldn't resolve an open alert from commit A — different UID). Now keyed on `gha-<repo>-<workflow>-<branch>`, so re-runs *and* follow-up commits on `main` collapse into one alert group.

Renamed the job `notify-irm-on-failure` → `notify-irm` to reflect the broader scope.

## New payload (failure)

```json
{
  "alert_uid": "gha-DevSecNinja/truenas-apps-Lint-main",
  "title": "CI failure on main: Lint",
  "state": "alerting",
  "severity": "critical",
  "link_to_upstream_details": "https://github.com/.../actions/runs/<id>",
  "message": "Workflow 'Lint' failed on main @ <sha> (actor: ...).",
  "labels": {
    "service": "ci",
    "service_name": "ci",
    "source": "github-actions",
    "repo": "DevSecNinja/truenas-apps",
    "workflow": "Lint",
    "branch": "main",
    "sha": "<short>",
    "actor": "<github_username>",
    "severity": "critical"
  }
}
```

## New payload (success — auto-resolve)

```json
{
  "alert_uid": "gha-DevSecNinja/truenas-apps-Lint-main",
  "title": "CI back to green on main: Lint",
  "state": "ok",
  "severity": "info",
  "message": "Workflow 'Lint' succeeded on main @ <sha> (actor: ...). Auto-resolving any open incident.",
  "labels": { "...": "...same shape, severity=info..." }
}
```

## Why both `service` and `service_name`?

IRM uses different keys in different surfaces (per the label-naming screen):

- SLOs / Alerts / Synthetic checks → `service_name`
- Incidents / Dashboard tags → `service`

Emitting both keeps every consumer happy without an integration-side rename.

## IRM UI requirements (one-time after merge)

### 1. Labels template

`Integrations → github-actions-ci → Labels` — paste:

```jinja
service: {{ payload.labels.service }}
service_name: {{ payload.labels.service_name }}
source: {{ payload.labels.source }}
repo: {{ payload.labels.repo }}
workflow: {{ payload.labels.workflow }}
branch: {{ payload.labels.branch }}
sha: {{ payload.labels.sha }}
actor: {{ payload.labels.actor }}
severity: {{ payload.labels.severity }}
```

### 2. Auto-resolution template

`Integrations → github-actions-ci → Auto resolution` — confirm it's already set to:

```jinja
{{ payload.get("state", "").upper() == "OK" }}
```

This is what turns the green-run payload into an auto-resolve.

### 3. Service association

Approach varies by IRM build — easiest is `Services → + New service → ci`. Older builds expose a Service dropdown on the integration; newer builds rely on the `service_name` label, which this PR now sends.

## Verification flow

1. After merge + Labels-template config, **Actions → Lint → Re-run failed jobs** on the #302 merge commit. `notify-irm` fires with `state=alerting`; same `alert_uid` reuses the existing alert group; the Assigned-labels pane should now show all 9 pairs.
2. **Auto-resolve test**: any successful push or merge to `main` afterward triggers `state=ok` on the same `alert_uid` → the alert group closes automatically.

## Validation

- `actionlint` ✓ (`failure()` isn't allowed in `env`; switched to `contains(needs.*.result, 'failure')`)
- `zizmor` ✓ — no findings
- `yamllint` ✓
- `yamlfmt -lint` ✓

## Rebase note

This branch is on top of `main` with #302's temporary `trigger-irm-failure-test` job still present. `notify-irm.needs:` still lists it. After #303 (revert) merges, the rebase should auto-resolve since the revert removes both the job and its entry in `needs`. If a conflict shows up, the resolution is to drop the `- trigger-irm-failure-test` line.

Refs #15