### PR TITLE
feat(alloy): alert on dccd deploy failures via Loki ruler + IRM

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -1228,6 +1228,20 @@ update_compose_files() {
                     log_result "FAILED: ${app}"
                 done
             fi
+
+            # Emit a single structured summary line at err priority so the
+            # Loki alert rule (services/alloy/rules/dccd.yaml) fires exactly
+            # once per dccd run, regardless of how many individual apps
+            # failed. Detected in LogQL via:
+            #     {unit="dccd"} |= "dccd_deploy_failed" | logfmt
+            # The `apps` field is a comma-separated list (no spaces) so it
+            # round-trips cleanly through logfmt parsing.
+            local _failed_csv
+            _failed_csv=$(
+                IFS=','
+                echo "${_DEPLOY_FAILED_APPS[*]}"
+            )
+            log_error "dccd_deploy_failed failed=${_DEPLOY_ERRORS} attempted=${_DEPLOY_ATTEMPTED} succeeded=${succeeded} apps=\"${_failed_csv}\""
         fi
         if [ "$((_DEPLOY_CHANGED + _DEPLOY_UNCHANGED))" -gt 0 ]; then
             log_result "${_DEPLOY_CHANGED} changed, ${_DEPLOY_UNCHANGED} unchanged"

--- a/scripts/publish-loki-rules.sh
+++ b/scripts/publish-loki-rules.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# publish-loki-rules.sh - Push Loki ruler YAML files to Grafana Cloud.
+#
+# Uploads every rule file under services/alloy/rules/*.yaml to the Grafana
+# Cloud Loki ruler API, one namespace per file (namespace is read from each
+# file's top-level `namespace:` key).
+#
+# Required environment:
+#   GRAFANA_LOKI_URL    e.g. https://logs-prod-012.grafana.net
+#   GRAFANA_LOKI_USER   numeric tenant / user id (Loki "username")
+#   GRAFANA_LOKI_TOKEN  Grafana Cloud access policy token with `logs:write`
+#
+# Usage:
+#   ./scripts/publish-loki-rules.sh           # publish all rule files
+#   ./scripts/publish-loki-rules.sh dccd      # publish a specific rule file
+#
+# This is a one-shot uploader; rerun it after editing any rule file.
+
+set -euo pipefail
+
+: "${GRAFANA_LOKI_URL:?GRAFANA_LOKI_URL is required}"
+: "${GRAFANA_LOKI_USER:?GRAFANA_LOKI_USER is required}"
+: "${GRAFANA_LOKI_TOKEN:?GRAFANA_LOKI_TOKEN is required}"
+
+repo_root=$(git rev-parse --show-toplevel)
+rules_dir="${repo_root}/services/alloy/rules"
+
+if [ ! -d "${rules_dir}" ]; then
+    echo "ERROR: rules directory not found: ${rules_dir}" >&2
+    exit 1
+fi
+
+files=()
+if [ "$#" -gt 0 ]; then
+    for name in "$@"; do
+        f="${rules_dir}/${name%.yaml}.yaml"
+        if [ ! -f "${f}" ]; then
+            echo "ERROR: rule file not found: ${f}" >&2
+            exit 1
+        fi
+        files+=("${f}")
+    done
+else
+    # shellcheck disable=SC2312  # find/sort exit codes in process substitution are non-fatal
+    while IFS= read -r -d '' f; do
+        files+=("${f}")
+    done < <(find "${rules_dir}" -maxdepth 1 -type f -name '*.yaml' -print0 | sort -z)
+fi
+
+if [ "${#files[@]}" -eq 0 ]; then
+    echo "No rule files to publish."
+    exit 0
+fi
+
+api="${GRAFANA_LOKI_URL%/}/loki/api/v1/rules"
+
+for f in "${files[@]}"; do
+    namespace=$(awk '/^namespace:/ { print $2; exit }' "${f}")
+    if [ -z "${namespace}" ]; then
+        echo "ERROR: ${f} has no top-level 'namespace:' key" >&2
+        exit 1
+    fi
+
+    # Strip the namespace key and upload only the `groups:` body, which is
+    # the format the Loki ruler API expects under /rules/<namespace>.
+    body=$(awk '
+        /^namespace:/ { skip=1; next }
+        /^[^[:space:]#]/ { skip=0 }
+        skip { next }
+        { print }
+    ' "${f}")
+
+    echo "Publishing ${f} -> namespace=${namespace}"
+    printf '%s\n' "${body}" | curl -fsSL \
+        --user "${GRAFANA_LOKI_USER}:${GRAFANA_LOKI_TOKEN}" \
+        -H "Content-Type: application/yaml" \
+        --data-binary @- \
+        "${api}/${namespace}"
+    echo "  ok"
+done

--- a/services/alloy/README.md
+++ b/services/alloy/README.md
@@ -129,6 +129,28 @@ Container logs **leave the network** to Grafana Cloud. The default `loki.source.
 
 If a service must never have its logs leave the network, exclude it temporarily by adding a `discovery.relabel` drop rule against `__meta_docker_container_name` in `config.alloy`.
 
+## Alerting Rules
+
+Loki ruler rules are committed under [`rules/`](rules/) and published to Grafana Cloud via [`scripts/publish-loki-rules.sh`](../../scripts/publish-loki-rules.sh). One YAML file per namespace; the script reads the `namespace:` key from each file and uploads the `groups:` body to `/loki/api/v1/rules/<namespace>` on the Grafana Cloud Loki ruler.
+
+Required environment for the publish script:
+
+- `GRAFANA_LOKI_URL` — e.g. `https://logs-prod-012.grafana.net`
+- `GRAFANA_LOKI_USER` — numeric tenant / Loki "username" from Grafana Cloud
+- `GRAFANA_LOKI_TOKEN` — Grafana Cloud access policy token with `logs:write`
+
+```sh
+export GRAFANA_LOKI_URL=...
+export GRAFANA_LOKI_USER=...
+export GRAFANA_LOKI_TOKEN=...
+bash scripts/publish-loki-rules.sh           # publish all rule files
+bash scripts/publish-loki-rules.sh dccd      # publish a single namespace
+```
+
+Current rules:
+
+- **`dccd`** ([rules/dccd.yaml](rules/dccd.yaml)) — fires `DccdDeployFailure` once per dccd run when one or more app deployments fail. The signal is the `dccd_deploy_failed` summary line emitted at err priority by `dccd.sh` at the end of every run with non-zero `_DEPLOY_ERRORS`. The expression aggregates `sum by (host)`, so multi-server failures stay separated, and the notification policy in Grafana Cloud should `Group by: alertname, host` to keep one IRM incident per host per failing run. Alert labels (`severity=critical`, `team=homelab`, `service=dccd`) are routed via the IRM contact point's notification policy.
+
 ## Reference
 
 - Alloy components: <https://grafana.com/docs/alloy/latest/reference/components/>

--- a/services/alloy/rules/dccd.yaml
+++ b/services/alloy/rules/dccd.yaml
@@ -1,0 +1,53 @@
+---
+# Grafana Cloud Loki ruler — dccd deploy-failure alert.
+#
+# Source signal: dccd.sh emits a single err-priority journal line at the end
+# of every run with one or more failed app deployments:
+#
+#   dccd_deploy_failed failed=2 attempted=18 succeeded=16 apps="immich,outline"
+#
+# The `unit=dccd` label is set by the Alloy journal pipeline
+# (services/alloy/config/config.alloy, transport-aware unit rule). The
+# `host` label is sourced from $HOSTNAME_OVERRIDE on each Alloy instance.
+#
+# Why this signal (and not per-app log_error lines): a single dccd run can
+# emit many err-priority lines (one per failed app, plus per-app stderr
+# from compose). Alerting on those would page once per failed app per run.
+# This dedicated summary line is emitted exactly once per dccd run, so
+# `count_over_time(...) > 0` produces exactly one alert per failing run
+# per host — and grouping by `host` in the notification policy keeps
+# multi-server failures separated.
+#
+# Publish to Grafana Cloud Loki ruler:
+#
+#   bash scripts/publish-loki-rules.sh
+#
+# (See services/alloy/README.md for required env vars and CI integration.)
+
+namespace: dccd
+groups:
+  - name: dccd
+    interval: 1m
+    rules:
+      - alert: DccdDeployFailure
+        # 6m window > 5m alloy max_age so we don't miss late-shipped entries.
+        # The summary line is emitted at most once per dccd cron run
+        # (every 5 min on svlnas), so any positive count is a real failure.
+        expr: |
+          sum by (host) (
+              count_over_time({unit="dccd"} |= "dccd_deploy_failed" [6m])
+          ) > 0
+        for: 0m
+        labels:
+          severity: critical
+          team: homelab
+          service: dccd
+        annotations:
+          summary: "dccd deploy failure on {{ $labels.host }}"
+          description: |
+            dccd.sh reported one or more failed app deployments on {{ $labels.host }}.
+            Inspect the run summary in Grafana Logs:
+              {unit="dccd", host="{{ $labels.host }}"} |= "dccd_deploy_failed" | logfmt
+            Or the full per-app failure detail:
+              {unit="dccd", host="{{ $labels.host }}", level="err"}
+          runbook_url: "https://github.com/DevSecNinja/truenas-apps/blob/main/docs/TROUBLESHOOTING.md"


### PR DESCRIPTION
## What

End-to-end IRM alerting for `dccd.sh` deploy failures, using the existing Alloy → Loki pipeline.

## How it works

```
dccd.sh end-of-run
    └── if _DEPLOY_ERRORS > 0:
        └── log_error "dccd_deploy_failed failed=N attempted=M succeeded=K apps=\"a,b,c\""
                  ↓ (logger -p user.err -t dccd → journald)
                  ↓ (Alloy journal pipeline, transport-aware unit rule from #301)
                  ↓ (Loki, with labels host=svlnas|svlazext|…, unit=dccd, level=err)
        └── Loki ruler evaluates `services/alloy/rules/dccd.yaml`:
                  expr: sum by (host) (
                          count_over_time({unit="dccd"} |= "dccd_deploy_failed" [6m])
                        ) > 0
        └── Grafana Alertmanager
                  routes severity=critical / team=homelab / service=dccd
                  → IRM contact point
                  groups by [alertname, host]   ← one incident per failing run per server
```

### Why a dedicated summary line, not a per-app alert

A single dccd run can emit many `level=err` lines (one per failed app, plus per-app compose stderr). Alerting on those would page **once per failed app per run**. The new `dccd_deploy_failed` line is emitted **exactly once per run** with non-zero failures, so:

- One alert per run per host — no matter if 1 or 10 apps failed.
- The `apps="…"` field carries the full failed-app list for the IRM annotation.
- The per-app `FAILED: <app>` lines are kept for log-trail readability.

### Server-aware grouping

The expression aggregates `sum by (host)`, so each server gets its own series and (with notification-policy `group_by: [alertname, host]`) its own IRM incident. svlnas and svlazext failing in the same window produce two separate alerts.

## Files

| File | Purpose |
|---|---|
| `scripts/dccd.sh` | Emits the structured summary line at err priority on failure |
| `services/alloy/rules/dccd.yaml` | Loki ruler YAML for `DccdDeployFailure` |
| `scripts/publish-loki-rules.sh` | curl-based uploader to `/loki/api/v1/rules/<ns>` |
| `services/alloy/README.md` | Documents the rule, env vars, grouping policy |

## Publishing the rule

```sh
export GRAFANA_LOKI_URL=https://logs-prod-012.grafana.net
export GRAFANA_LOKI_USER=...
export GRAFANA_LOKI_TOKEN=...   # access policy with logs:write
bash scripts/publish-loki-rules.sh
```

Idempotent — rerun after every rule edit. (Could be wired into CI later; deferring per-issue scope.)

## Grafana Cloud one-time setup (UI, not in repo)

1. Contact point: existing `grafana-default-irm` (auto-created by IRM integration)
2. Notification policy: match `team=homelab` AND `severity=critical` → IRM contact point, `group_by: [alertname, host]`, `group_interval: 5m`, `repeat_interval: 4h`
3. IRM escalation chain: phone first, mute window for known maintenance

## Validation

- `shellcheck` / `shfmt` clean on `dccd.sh` + `publish-loki-rules.sh`
- `yamlfmt` / `yamllint` clean on `rules/dccd.yaml`
- `dprint check` clean on `services/alloy/README.md`
- `bash -n scripts/dccd.sh` syntax-OK
- Live rule load deferred to post-merge (requires Grafana Cloud token)

Refs #15
Builds on #301 (transport-aware `unit` label) and #304 (IRM payload labels for service-based routing).
