### PR TITLE
feat(ci): consume DevSecNinja/.github notify-irm action across workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,3 +62,21 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+  # --- Page on main-branch docs-build/deploy failure (Phase 3 of #15) ---
+  notify-irm:
+    name: Notify Grafana IRM
+    needs:
+      - build
+      - deploy
+    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Grafana IRM
+        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        with:
+          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
+          # `needs.*.result` is system-controlled, safe to interpolate.
+          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -73,3 +73,24 @@ jobs:
         with:
           sarif_file: sarif-output/trivy-images.sarif
           category: trivy-images
+
+  # --- Page on scheduled/manual run failure (Phase 3 of #15) ---
+  # PR runs are excluded — they only execute on workflow-file edits and a
+  # red PR check is signal enough. Schedule + workflow_dispatch failures
+  # warrant a page because nobody is watching the run interactively.
+  notify-irm:
+    name: Notify Grafana IRM
+    needs:
+      - image-age-check
+      - trivy-image-scan
+    if: ${{ always() && github.event_name != 'pull_request' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Grafana IRM
+        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        with:
+          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
+          # `needs.*.result` is system-controlled, safe to interpolate.
+          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -142,88 +142,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: POST alert state to Grafana IRM webhook
-        env:
-          WEBHOOK_URL: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          RUN_ID: ${{ github.run_id }}
-          REPOSITORY: ${{ github.repository }}
-          REF_NAME: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          ACTOR: ${{ github.actor }}
-          SERVER_URL: ${{ github.server_url }}
-          # Whether any required job ended in failure (or was cancelled).
+      - name: Notify Grafana IRM
+        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        with:
+          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.
-          JOB_FAILED: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
-        run: |-
-          set -euo pipefail
-          if [ -z "${WEBHOOK_URL}" ]; then
-            echo "::warning::GRAFANA_IRM_WEBHOOK_URL secret not set — skipping IRM notification."
-            exit 0
-          fi
-          run_url="${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID}"
-
-          # Branch the payload by outcome.
-          # alert_uid is intentionally NOT keyed on SHA: a successful run on a
-          # later commit (different SHA) must resolve the open incident from
-          # the previous failed commit. Re-runs of the same workflow on any
-          # commit on `main` collapse into the same alert group.
-          if [ "${JOB_FAILED}" = "true" ]; then
-            state="alerting"
-            severity="critical"
-            title="CI failure on main: ${WORKFLOW_NAME}"
-            msg="Workflow '${WORKFLOW_NAME}' failed on ${REF_NAME} @ ${SHA} (actor: ${ACTOR})."
-          else
-            state="ok"
-            severity="info"
-            title="CI back to green on main: ${WORKFLOW_NAME}"
-            msg="Workflow '${WORKFLOW_NAME}' succeeded on ${REF_NAME} @ ${SHA} (actor: ${ACTOR}). Auto-resolving any open incident."
-          fi
-          echo "::notice::Posting state=${state} for ${WORKFLOW_NAME} on ${REF_NAME} @ ${SHA:0:7}"
-
-          # Grafana IRM "Custom" webhook payload — fields map to the standard
-          # alert grouping keys. The `labels` object is the homelab convention
-          # for IRM routing/filtering — IRM surfaces it in the alert-group
-          # "Assigned labels" pane. Both `service` and `service_name` are sent
-          # because IRM uses `service_name` for SLOs/alerts/synthetic checks
-          # but `service` for incident & dashboard tags; emitting both keeps
-          # every consumer happy without an integration-side rename.
-          payload=$(jq -n \
-            --arg uid "gha-${REPOSITORY}-${WORKFLOW_NAME}-${REF_NAME}" \
-            --arg title "${title}" \
-            --arg state "${state}" \
-            --arg severity "${severity}" \
-            --arg link "${run_url}" \
-            --arg msg "${msg}" \
-            --arg service "ci" \
-            --arg source "github-actions" \
-            --arg repo "${REPOSITORY}" \
-            --arg workflow "${WORKFLOW_NAME}" \
-            --arg branch "${REF_NAME}" \
-            --arg sha_short "${SHA:0:7}" \
-            --arg actor "${ACTOR}" \
-            '{
-              alert_uid: $uid,
-              title: $title,
-              state: $state,
-              severity: $severity,
-              link_to_upstream_details: $link,
-              message: $msg,
-              labels: {
-                service: $service,
-                service_name: $service,
-                source: $source,
-                repo: $repo,
-                workflow: $workflow,
-                branch: $branch,
-                sha: $sha_short,
-                actor: $actor,
-                severity: $severity
-              }
-            }')
-          curl --silent --show-error --fail-with-body \
-            --max-time 30 \
-            --request POST \
-            --header 'Content-Type: application/json' \
-            --data "${payload}" \
-            "${WEBHOOK_URL}"
+          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,24 @@ jobs:
       # renovate: datasource=github-releases depName=jdx/mise
       mise-version: "2026.4.15"
       tag: ${{ github.ref_name }}
+
+  # --- Page on tag-push release failure (Phase 3 of #15) ---
+  # alert_uid is keyed on the tag (REF_NAME), so each release has its own
+  # alert group. resolve-on-success is disabled because there is no
+  # subsequent run on the same tag to post a green resolve.
+  notify-irm:
+    name: Notify Grafana IRM
+    needs:
+      - release
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Grafana IRM
+        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        with:
+          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
+          # `needs.*.result` is system-controlled, safe to interpolate.
+          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+          resolve-on-success: "false"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,21 @@ jobs:
       mise-version: "2026.4.15"
       test-dirs: "tests/dccd/e2e"
       check-name: "dccd E2E Tests"
+
+  # --- Page on main-branch CI failure (Phase 3 of #15) ---
+  notify-irm:
+    name: Notify Grafana IRM
+    needs:
+      - unit-integration
+      - e2e
+    if: ${{ always() && github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Notify Grafana IRM
+        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        with:
+          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
+          # `needs.*.result` is system-controlled, safe to interpolate.
+          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
## Summary

Phase 3 (#15) rollout: replaces the inline `notify-irm` job in `lint.yml` with a call to the new reusable composite action [`DevSecNinja/.github/.github/actions/notify-irm`](https://github.com/DevSecNinja/.github/blob/main/.github/actions/notify-irm/action.yml) (added in [DevSecNinja/.github#51](https://github.com/DevSecNinja/.github/pull/51)) and adds matching `notify-irm` jobs to every other push-triggered workflow so a main-branch CI failure pages Grafana IRM and a green follow-up auto-resolves the open incident.

## Workflows extended

| Workflow | Trigger gating the page | `resolve-on-success` |
| --- | --- | --- |
| `lint.yml` | `push` to `main` (refactored from inline job) | default `true` |
| `test.yml` (BATS unit/integration + e2e) | `push` to `main` | default `true` |
| `image-security.yml` (Trivy + image-age scans) | `schedule` + `workflow_dispatch` (PR runs excluded) | default `true` |
| `release.yml` (tag-push release publishing) | every run (`if: always()`) | **`false`** — `alert_uid` is keyed on the tag and never re-fires |
| `docs.yml` (mkdocs build + GitHub Pages deploy) | `push` to `main` | default `true` |

## How `alert_uid` works

`gha-<repo>-<workflow>-<branch>` (no SHA) — each workflow has its own alert group, and successful re-runs or follow-up commits on the same branch resolve the open incident from a previous failed commit. `release.yml` uses `resolve-on-success: false` because `REF_NAME` is the tag (unique per release), so a green run on a new tag has nothing to resolve.

## Verification

- `mise exec -- yamlfmt -lint`, `yamllint`, `actionlint`, `zizmor` — all clean on the five edited files.
- The composite action itself is pinned to `a877d352` (merge SHA of DevSecNinja/.github#51 on `main`).

Refs #15.