### PR TITLE
feat(gatus): add digitalsecurity endpoint health check

### DIFF
--- a/services/gatus/config/config.yaml
+++ b/services/gatus/config/config.yaml
@@ -156,6 +156,16 @@ endpoints:
       - "[CERTIFICATE_EXPIRATION] > 48h"
       - "[RESPONSE_TIME] < 1000"
 
+  - name: digitalsecurity - HTTP
+    <<: *defaults
+    url: "https://digitalsecurity.${DOMAINNAME}"
+    group: External
+    conditions:
+      - "[BODY] == pat(*DIGITAL SECURITY FOR NONPROFIT LEADERS*)"
+      - "[STATUS] == 200"
+      - "[CERTIFICATE_EXPIRATION] > 48h"
+      - "[RESPONSE_TIME] < 1000"
+
   - name: traefik-ext - HTTP
     <<: *defaults
     url: "https://traefik-ext.${DOMAINNAME}"


### PR DESCRIPTION
Adds a Gatus health check for `https://digitalsecurity.${DOMAINNAME}` in the External group, asserting status 200, valid certificate, response time under 1s, and a body match for `DIGITAL SECURITY FOR NONPROFIT LEADERS` in the footer.