### PR TITLE
chore(ci): bump notify-irm action to b2509636

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -89,7 +89,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -143,7 +143,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       contents: read
     steps:
       - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@a877d35266a54e54ef043e60a290ed76b4d7b34e # main
+        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
         with:
           webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
           # `needs.*.result` is system-controlled, safe to interpolate.


### PR DESCRIPTION
Bumps the `notify-irm` composite action pin from `a877d352` to `b2509636` to pick up [DevSecNinja/.github#53](https://github.com/DevSecNinja/.github/pull/53), which removes `${{ }}` templates from `description:` blocks in `action.yml`.

The previous pin failed at action-load time with:

```
Unrecognized function: 'always'.
```

because GitHub Actions evaluates `${{ }}` expressions inside `description:` blocks, and the embedded usage example contained `always()` (only valid in workflow `if:` contexts).

5 workflows updated: `lint.yml`, `test.yml`, `image-security.yml`, `release.yml`, `docs.yml`.