### PR TITLE
fix(gatus): update digital security body match pattern

### DIFF
--- a/services/gatus/config/config.yaml
+++ b/services/gatus/config/config.yaml
@@ -161,7 +161,7 @@ endpoints:
     url: "https://digitalsecurity.${DOMAINNAME}"
     group: External
     conditions:
-      - "[BODY] == pat(*DIGITAL SECURITY FOR NONPROFIT LEADERS*)"
+      - "[BODY] == pat(*Digital Security for Nonprofit Leaders*)"
       - "[STATUS] == 200"
       - "[CERTIFICATE_EXPIRATION] > 48h"
       - "[RESPONSE_TIME] < 1000"


### PR DESCRIPTION
Updates the body-match pattern for the `digitalsecurity` endpoint to match the actual page text casing (`Digital Security for Nonprofit Leaders`) rather than the previous all-caps string.