### PR TITLE
chore: open release-please PRs as drafts

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
+  "draft-pull-request": true,
   "prerelease": false,
   "packages": {
     ".": {


### PR DESCRIPTION
Sets `draft-pull-request: true` so release-please opens the recurring `chore(main): release …` PR as a draft. CI workflows that filter on `pull_request` (non-draft) are skipped until the PR is marked ready for review, cutting churn on every commit to `main`.

Docs: https://github.com/googleapis/release-please/blob/main/docs/customizing.md#opening-as-a-draft-pull-request