### PR TITLE
chore(release): align bump-minor-pre-major: false with .github

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "skip-github-release": false,
-  "bump-minor-pre-major": true,
+  "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "draft": false,
   "draft-pull-request": true,


### PR DESCRIPTION
## Why

Align pre-1.0 bump policy across all three repos (`DevSecNinja/.github`, `DevSecNinja/dotfiles`, `DevSecNinja/truenas-apps`).

`.github` already uses `bump-minor-pre-major: false`. Setting the same here means:

- `feat:` → patch bump (`0.0.x`)
- `BREAKING CHANGE:` (or `feat!:`) → minor bump (`0.x.0`)

Previously every `feat:` rolled the minor digit (e.g. 0.18.0 → 0.19.0 from a normal feature commit). With this change, minors are reserved for breaking changes — the standard semver pre-1.0 interpretation.

Companion change in dotfiles: DevSecNinja/dotfiles#261 (already includes this update).