### PR TITLE
chore(gatus): remove body check for digitalsecurity endpoint

### DIFF
--- a/services/gatus/config/config.yaml
+++ b/services/gatus/config/config.yaml
@@ -161,7 +161,6 @@ endpoints:
     url: "https://digitalsecurity.${DOMAINNAME}"
     group: External
     conditions:
-      - "[BODY] == pat(*Digital Security for Nonprofit Leaders*)"
       - "[STATUS] == 200"
       - "[CERTIFICATE_EXPIRATION] > 48h"
       - "[RESPONSE_TIME] < 1000"


### PR DESCRIPTION
Removes the `[BODY] == pat(*Digital Security for Nonprofit Leaders*)` condition from the digitalsecurity endpoint check in Gatus. The remaining status, certificate, and response-time conditions still validate availability.