### PR TITLE
fix(bitwarden): own bitwarden-frontend network instead of declaring it external

### DIFF
--- a/services/bitwarden/compose.yaml
+++ b/services/bitwarden/compose.yaml
@@ -154,4 +154,4 @@ services:
 networks:
   bitwarden-frontend:
     name: bitwarden-frontend
-    external: true
+    driver: bridge


### PR DESCRIPTION
## Problem

After merging #319, the deploy failed with:

```
[2026/05/01 15:04:55] (ERROR) app_lifecycle.compose_action():56 - Failed 'up' action for 'bitwarden' app: network bitwarden-frontend declared as external, but could not be found
```

Both `services/bitwarden/compose.yaml` and `services/traefik/compose.yaml` declared `bitwarden-frontend` as `external: true`, so neither stack actually created the network.

## Fix

Per the repo convention (see `frigate`, `sqlite-web`, etc.), the **app owns its frontend network** with `driver: bridge`, and Traefik joins it as `external: true`. This patch flips the bitwarden side to `driver: bridge` so the network is created when the bitwarden stack comes up.

```diff
 networks:
   bitwarden-frontend:
     name: bitwarden-frontend
-    external: true
+    driver: bridge
```

Traefik's declaration is unchanged.

## Validation

- `docker compose -f services/bitwarden/compose.yaml config --quiet` → no errors
- Pattern matches every other frontend network in the repo