### PR TITLE
fix(bitwarden): use 127.0.0.1 in healthcheck to avoid IPv6 localhost

### DIFF
--- a/services/bitwarden/compose.yaml
+++ b/services/bitwarden/compose.yaml
@@ -145,7 +145,12 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:8080/alive"
+        # Use 127.0.0.1 explicitly — Alpine's /etc/hosts resolves "localhost"
+        # to ::1 first, but the rendered nginx config only listens on
+        # 0.0.0.0:8080 (IPv6 listener fails to bind on hosts without IPv6
+        # bridge support, e.g. TrueNAS). busybox wget does not fall back to
+        # IPv4, so localhost always reports "Connection refused".
+        - "http://127.0.0.1:8080/alive"
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Problem

The bitwarden container is reported `unhealthy` even though all .NET services run cleanly and nginx is bound on `0.0.0.0:8080`:

```
"Status": "unhealthy", "FailingStreak": 22,
"Output": "wget: can't connect to remote host: Connection refused\n"
```

```
admin         RUNNING   pid 56, uptime 0:11:27
api           RUNNING   pid 55, uptime 0:11:27
identity      RUNNING   pid 54, uptime 0:11:27
nginx         RUNNING   pid 58, uptime 0:11:27
notifications RUNNING   pid 57, uptime 0:11:27
```

```
tcp  0  0 0.0.0.0:8080  0.0.0.0:*  LISTEN
```

## Root cause

Alpine resolves `localhost` to `::1` (IPv6) before `127.0.0.1`. The rendered nginx config tries to bind both IPv4 and IPv6, but the IPv6 listener fails on hosts without IPv6 bridge support (TrueNAS default), so nginx ends up bound on **IPv4 only**. Busybox `wget` does not fall back to IPv4 after a refused IPv6 connection — every probe just returns `Connection refused`.

## Fix

Pin the healthcheck URL to `127.0.0.1` so the probe always uses the listener nginx actually has.

```diff
-        - "http://localhost:8080/alive"
+        - "http://127.0.0.1:8080/alive"
```

Inline comment explains why for the next reader.

## Validation

- `docker compose -f services/bitwarden/compose.yaml config --quiet` → no errors
- Locally reproduced: `wget --spider -q http://localhost:8080/alive` exits 1 from inside the container; `http://127.0.0.1:8080/alive` exits 0