### PR TITLE
chore(healthchecks): use 127.0.0.1 instead of localhost across all services

### DIFF
--- a/services/adguard/compose.yaml
+++ b/services/adguard/compose.yaml
@@ -283,7 +283,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:80"
+        - "http://127.0.0.1:80"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/alloy/compose.yaml
+++ b/services/alloy/compose.yaml
@@ -195,7 +195,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:2375/_ping"
+        - "http://127.0.0.1:2375/_ping"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/services/bazarr/compose.yaml
+++ b/services/bazarr/compose.yaml
@@ -57,7 +57,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:6767/ping"
+        - "http://127.0.0.1:6767/ping"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/dozzle/compose.yaml
+++ b/services/dozzle/compose.yaml
@@ -147,7 +147,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:2375/_ping"
+        - "http://127.0.0.1:2375/_ping"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/services/drawio/compose.yaml
+++ b/services/drawio/compose.yaml
@@ -38,7 +38,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:8080"
+        - "http://127.0.0.1:8080"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/echo-server/compose.yaml
+++ b/services/echo-server/compose.yaml
@@ -66,7 +66,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:${HTTP_PORT:-80}"
+        - "http://127.0.0.1:${HTTP_PORT:-80}"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/esphome/compose.yaml
+++ b/services/esphome/compose.yaml
@@ -35,7 +35,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "curl -sf http://localhost:6052/ -o /dev/null || exit 1"
+        - "curl -sf http://127.0.0.1:6052/ -o /dev/null || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/excalidraw/compose.yaml
+++ b/services/excalidraw/compose.yaml
@@ -47,7 +47,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:80"
+        - "http://127.0.0.1:80"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/frigate/compose.yaml
+++ b/services/frigate/compose.yaml
@@ -87,7 +87,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "curl -sf http://localhost:5000/api/version -o /dev/null || exit 1"
+        - "curl -sf http://127.0.0.1:5000/api/version -o /dev/null || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/gatus/compose.yaml
+++ b/services/gatus/compose.yaml
@@ -314,7 +314,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:2375/_ping"
+        - "http://127.0.0.1:2375/_ping"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/services/home-assistant/compose.yaml
+++ b/services/home-assistant/compose.yaml
@@ -84,7 +84,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "curl -sf http://localhost:8123/ -o /dev/null || exit 1"
+        - "curl -sf http://127.0.0.1:8123/ -o /dev/null || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/homepage/compose.yaml
+++ b/services/homepage/compose.yaml
@@ -50,7 +50,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:3000"
+        - "http://127.0.0.1:3000"
       interval: 15s
       timeout: 5s
       retries: 3
@@ -118,7 +118,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:2375/_ping"
+        - "http://127.0.0.1:2375/_ping"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/services/immich/compose.yaml
+++ b/services/immich/compose.yaml
@@ -99,7 +99,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:2283/api/server/ping"
+        - "http://127.0.0.1:2283/api/server/ping"
       interval: 15s
       timeout: 5s
       retries: 3
@@ -188,7 +188,7 @@ services:
         - "CMD"
         - "python3"
         - "-c"
-        - "import urllib.request; urllib.request.urlopen('http://localhost:3003/ping')"
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:3003/ping')"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/lidarr/compose.yaml
+++ b/services/lidarr/compose.yaml
@@ -57,7 +57,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8686/ping"
+        - "http://127.0.0.1:8686/ping"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/matter-server/compose.yaml
+++ b/services/matter-server/compose.yaml
@@ -97,7 +97,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:5580')\" 2>/dev/null || exit 1"
+        - "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:5580')\" 2>/dev/null || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/metube/compose.yaml
+++ b/services/metube/compose.yaml
@@ -89,7 +89,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8081"
+        - "http://127.0.0.1:8081"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/outline/compose.yaml
+++ b/services/outline/compose.yaml
@@ -102,7 +102,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - "wget -qO- http://localhost:3000/_health || exit 1"
+        - "wget -qO- http://127.0.0.1:3000/_health || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3

--- a/services/plex/compose.yaml
+++ b/services/plex/compose.yaml
@@ -81,7 +81,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:32400/identity"
+        - "http://127.0.0.1:32400/identity"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/prowlarr/compose.yaml
+++ b/services/prowlarr/compose.yaml
@@ -56,7 +56,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:9696/ping"
+        - "http://127.0.0.1:9696/ping"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/qbittorrent/compose.yaml
+++ b/services/qbittorrent/compose.yaml
@@ -59,7 +59,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8080"
+        - "http://127.0.0.1:8080"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/radarr/compose.yaml
+++ b/services/radarr/compose.yaml
@@ -57,7 +57,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:7878/ping"
+        - "http://127.0.0.1:7878/ping"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/sabnzbd/compose.yaml
+++ b/services/sabnzbd/compose.yaml
@@ -57,7 +57,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8080/"
+        - "http://127.0.0.1:8080/"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/sonarr/compose.yaml
+++ b/services/sonarr/compose.yaml
@@ -57,7 +57,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8989/ping"
+        - "http://127.0.0.1:8989/ping"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/spottarr/compose.yaml
+++ b/services/spottarr/compose.yaml
@@ -86,7 +86,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:8383"
+        - "http://127.0.0.1:8383"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/traefik/compose.yaml
+++ b/services/traefik/compose.yaml
@@ -203,7 +203,7 @@ services:
         - "wget"
         - "--spider"
         - "-q"
-        - "http://localhost:2375/_ping"
+        - "http://127.0.0.1:2375/_ping"
       interval: 5s
       timeout: 5s
       retries: 3

--- a/services/tubesync/compose.yaml
+++ b/services/tubesync/compose.yaml
@@ -47,7 +47,7 @@ services:
         - "CMD"
         - "curl"
         - "-f"
-        - "http://localhost:4848"
+        - "http://127.0.0.1:4848"
       interval: 15s
       timeout: 5s
       retries: 3

--- a/services/unifi/compose.yaml
+++ b/services/unifi/compose.yaml
@@ -163,7 +163,7 @@ services:
         - "CMD"
         - "curl"
         - "-fkL"
-        - "https://localhost:8443"
+        - "https://127.0.0.1:8443"
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary

Migrates every healthcheck `localhost` to `127.0.0.1` across all 27 services. Codified by [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) in #322 after the bitwarden regression; this PR brings the rest of the repo into compliance.

## Why

Alpine (and several other minimal bases) resolves `localhost` to `::1` (IPv6) before `127.0.0.1`. When the application binds IPv4-only — the common path on hosts without IPv6 bridge support, including TrueNAS by default — the healthcheck probe fails with `Connection refused`. Busybox `wget` and many minimal probe binaries do not fall back to IPv4 after a refused IPv6 connection. The container is fully healthy but reports `unhealthy` forever.

These 27 services are healthy today only because their bases happen to bind IPv6 successfully. Pinning to `127.0.0.1` removes the latent timebomb across the fleet.

## Change

Mechanical: `sed -i 's|//localhost:|//127.0.0.1:|g'` across `services/*/compose.yaml`. Verified that all `://localhost:` matches were inside `healthcheck.test:` blocks (the only remaining `localhost` occurrences in compose files are non-URL comments in `adguard` and `matter-server`).

## Validation

- `docker compose -f services/<each>/compose.yaml config --quiet` — all pass
- `git diff --stat`: 27 files changed, 29 insertions(+), 29 deletions(-)

## Affected services

`adguard`, `alloy`, `bazarr`, `dozzle`, `drawio`, `echo-server`, `esphome`, `excalidraw`, `frigate`, `gatus`, `home-assistant`, `homepage` (×2), `immich` (×2), `lidarr`, `matter-server`, `metube`, `outline`, `plex`, `prowlarr`, `qbittorrent`, `radarr`, `sabnzbd`, `sonarr`, `spottarr`, `traefik`, `tubesync`, `unifi`