### PR TITLE
feat(bitwarden): dedicated CSP middleware for HIBP and Duo MFA

### DIFF
--- a/services/bitwarden/compose.yaml
+++ b/services/bitwarden/compose.yaml
@@ -119,20 +119,20 @@ services:
       ### their own authentication via the Bitwarden API/Identity services.
       - "traefik.http.routers.bitwarden-rtr.rule=Host(`vault.${DOMAINNAME}`)"
       - "traefik.http.routers.bitwarden-rtr.entrypoints=https"
-      - "traefik.http.routers.bitwarden-rtr.middlewares=chain-no-auth@file"
+      - "traefik.http.routers.bitwarden-rtr.middlewares=chain-no-auth-bitwarden@file"
       - "traefik.http.routers.bitwarden-rtr.service=bitwarden"
       ### Admin panel — protected by Traefik Forward Auth in addition to
       ### the built-in admin authentication (defence in depth).
       - "traefik.http.routers.bitwarden-admin-rtr.rule=Host(`vault.${DOMAINNAME}`) && PathPrefix(`/admin`)"
       - "traefik.http.routers.bitwarden-admin-rtr.entrypoints=https"
-      - "traefik.http.routers.bitwarden-admin-rtr.middlewares=chain-auth@file"
+      - "traefik.http.routers.bitwarden-admin-rtr.middlewares=chain-auth-bitwarden@file"
       - "traefik.http.routers.bitwarden-admin-rtr.service=bitwarden"
       ## HTTP Services
       - "traefik.http.services.bitwarden.loadbalancer.server.port=8080"
       ## Monitoring (Gatus — internal entrypoint only, no auth)
       - "traefik.http.routers.bitwarden-monitor.rule=Host(`vault.${DOMAINNAME}`)"
       - "traefik.http.routers.bitwarden-monitor.entrypoints=monitoring"
-      - "traefik.http.routers.bitwarden-monitor.middlewares=chain-no-auth@file"
+      - "traefik.http.routers.bitwarden-monitor.middlewares=chain-no-auth-bitwarden@file"
       - "traefik.http.routers.bitwarden-monitor.service=bitwarden"
       ## Gatus
       - "gatus.url=http://172.30.100.6:8444"

--- a/services/bitwarden/secret.sops.env
+++ b/services/bitwarden/secret.sops.env
@@ -7,7 +7,7 @@ BW_INSTALLATION_KEY=ENC[AES256_GCM,data:+hLKVFjCfEjj2T3XgnLW/mDnx8c=,iv:I4/AHPG9
 #ENC[AES256_GCM,data:KxdS81TTejvrFsbD0gOqT7OGlQXt8AhTYSqfXwK+4VC6KUjj4cZIuEcnjruULpdY29f8jI3Q,iv:SnqavRxTvAXi2wIxLtEmfpWzZ7+qn3YtolAv6oRndxY=,tag:S0tLtnCm78rjDScvLDYIAg==,type:comment]
 BW_ADMIN_EMAILS=ENC[AES256_GCM,data:YyX0g8gwBv1SFYs6Wl71Fv7MKybFTzEY,iv:BrUtL4tzXFpUnD67PMxK2aLUjFy+dglPMmBas3TefGg=,tag:UaHWn019sM/jCd7kkLGs8g==,type:str]
 #ENC[AES256_GCM,data:PxBuL4VT5Kvfwy6hSBwsHsRMG3k0cPalqTxJ8czBDwJiFulJU8eHxy6yLrUOIy1pzrywhVfR8SnIyVgvoVZL04s+I4fHuD1agok=,iv:Rzs0zEY46x/Y9ONRV7zJV4Nztn/+F98zcaqY5FoK3HY=,tag:YQNpAkwBYRFAqffs/cK2Rg==,type:comment]
-BW_DISABLE_USER_REGISTRATION=ENC[AES256_GCM,data:28eGNRU=,iv:L5hUohvIrsI02I86k8oNjvp2jhhC6FGNJr2D5yGrESo=,tag:LeCluGr5AUFJGCu8UqANsQ==,type:str]
+BW_DISABLE_USER_REGISTRATION=ENC[AES256_GCM,data:hbFWlg==,iv:uM7A7McsIf0LEXzWpwMBlsg4199MFRYf84kB2g/Ovjk=,tag:6pob3d0XhIV4aAWm6M6wLQ==,type:str]
 #ENC[AES256_GCM,data:SdNucZPnQGLfYwm3kjnKa9B+uECukCf/+hdbynppC5Fp8zVbBMR0Tonsgxpk/2PSruRHMU7ZzHectxem5VA/FzEFoBObImTY,iv:VxjCvjGpEDAhy4+PDL+amon7mqqHcw/MYsoh7aSsoxc=,tag:EbVSr/Q22zhxIFbzoy9myQ==,type:comment]
 NOTIFICATIONS_EMAIL_FROM=ENC[AES256_GCM,data:rZvxZKc4RvEFSjMdqLQ9lHgPcVXKQPkKqkduP2L8oQs=,iv:kEFe9x/GxAgF4e3c9XC+oHhiL4HERoTXD0Tirq5kcNw=,tag:x6tsR0K7xklaZj9OffrzIg==,type:str]
 NOTIFICATIONS_EMAIL_TO=ENC[AES256_GCM,data:2ifFcQZkxucVyEdnneb26QSqZJvIk5UF,iv:eTm+nl7QMXoX5qoGaE2INoAkMuBC4plS/B/ZlL01TQc=,tag:0W0NV7XWfeYFij09NLxyjw==,type:str]
@@ -26,7 +26,7 @@ sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb2
 sops_age__list_0__map_recipient=age18mdfujf864x66ys9slshhzknnq5argngyhu55zqenccjdf9fd3lqgpyp6n
 sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRSFJ3b0xuUU93T3RBY3VO\nemQ3NS9icXp0di9WOWF2N3JicEZSWUV0MHk4CkxWZGNKY3VsRGV0dHp2ejJ0c0NR\nSHFhY3VJNFc1ZjBOREVsNEtMOFJMWmcKLS0tIERWc3JXV2djTFF0a0pFVWtZSFpY\nZUlIdGpIc0ZxdW5ZV213L2pvaHkyV1kKjSl7zc5Yo3DOLN9uieoeHZierxyhEPup\nFYg9GdzyU28LJr+gFSL4+la3skLdhJWjFdv25BY680b4gRW2+EJyBQ==\n-----END AGE ENCRYPTED FILE-----\n
 sops_age__list_1__map_recipient=age1dgw6l56j4qu7jnh06n9z7rpctgar3stk8hnxq3es9j88yqjpzdvqkrp7en
-sops_lastmodified=2026-05-01T12:50:05Z
-sops_mac=ENC[AES256_GCM,data:o8PipTq0ihSd2Ojj7C3Vv4R3Ytn/+GVrfHCIawt8hz4YJ5qNxxna3FaXld1uetY9XWLk4XzguwLTyzfTRecDBVBb51cHRh621Hn/feVdRtTfQU8kkml5dCQVT9tcssgBa74d48uBDQNIvaeRHYD+LgW+frQrensgbKfhyOLyIGc=,iv:ce3qkQxJZb9MCZ34lsWI6aKsJTgo4OrVaRkDqQqdn04=,tag:gErXECQltpsW2I54Rl0ztw==,type:str]
+sops_lastmodified=2026-05-01T13:44:43Z
+sops_mac=ENC[AES256_GCM,data:rz1WjTTP3lYWmeJy9wf/YuLiHa9kHwDb0UKmhtYM8mQdmKrZ/YJ0rSgyZd+RBlRkx1d99mqeZqU9SmF6YC8Y64RTSEA0KrNu73EvvzXGYBkS5PQ5GXT11elbkOo154/zDreUCtyOZDXAoQjegqmYETaaHv69uMw1wVvhelfzys0=,iv:k7WuSiKeg9kFSrKsewzZ0aUUWovzKNuOk9+CV91J1hw=,tag:J+b1HNQzyzdMrO7CBrOo/g==,type:str]
 sops_unencrypted_suffix=_unencrypted
 sops_version=3.12.2

--- a/services/traefik/config/rules/middlewares-chains.yml
+++ b/services/traefik/config/rules/middlewares-chains.yml
@@ -33,6 +33,17 @@ http:
           - "middlewares-rate-limit"
           - "middlewares-qbittorrent-secure-headers"
           - "middlewares-forward-auth"
+    chain-no-auth-bitwarden:
+      chain:
+        middlewares:
+          - "middlewares-rate-limit"
+          - "middlewares-bitwarden-secure-headers"
+    chain-auth-bitwarden:
+      chain:
+        middlewares:
+          - "middlewares-rate-limit"
+          - "middlewares-bitwarden-secure-headers"
+          - "middlewares-forward-auth"
     chain-auth:
       chain:
         middlewares:

--- a/services/traefik/config/rules/middlewares.yml
+++ b/services/traefik/config/rules/middlewares.yml
@@ -142,6 +142,45 @@ http:
           server: ""
           Content-Security-Policy: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self'
             'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'"
+    # Standalone Bitwarden-specific headers middleware — replaces middlewares-secure-headers
+    # for Bitwarden Lite. The Bitwarden web vault needs:
+    #   - connect-src: api.pwnedpasswords.com (HIBP password-strength check),
+    #     api.2fa.directory (2FA provider hints), app.simplelogin.io (alias generator)
+    #   - script-src 'wasm-unsafe-eval': required for the Argon2 KDF wasm module
+    #   - img-src haveibeenpwned.com: HIBP breach-result icons
+    #   - child-src/frame-src duosecurity/duofederal: Duo MFA iframe
+    #   - object-src 'self' blob:: required for vault attachments
+    # Mirrors the CSP rendered by upstream Bitwarden's nginx-config.hbs but with
+    # frame-ancestors 'none' added for clickjacking protection (the upstream
+    # CSP omits frame-ancestors).
+    middlewares-bitwarden-secure-headers:
+      headers:
+        accessControlAllowMethods:
+          - "GET"
+          - "OPTIONS"
+          - "PUT"
+        accessControlMaxAge: 100
+        hostsProxyHeaders:
+          - "X-Forwarded-Host"
+        stsSeconds: 63072000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        forceSTSHeader: true
+        customFrameOptionsValue: "DENY"
+        contentTypeNosniff: true
+        browserXssFilter: true
+        referrerPolicy: "same-origin"
+        permissionsPolicy: "camera 'none'; geolocation 'none'; microphone 'none'; payment 'none'; usb 'none'; vr 'none';"
+        customRequestHeaders:
+          X-Forwarded-Proto: https
+        customResponseHeaders:
+          X-Robots-Tag: "none,noarchive,nosnippet,notranslate,noimageindex,"
+          server: ""
+          Content-Security-Policy: "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline';
+            img-src 'self' data: https://haveibeenpwned.com; font-src 'self' data:; child-src 'self' https://*.duosecurity.com
+            https://*.duofederal.com; frame-src 'self' https://*.duosecurity.com https://*.duofederal.com; connect-src 'self'
+            https://api.pwnedpasswords.com https://api.2fa.directory https://app.simplelogin.io/api/alias/random/new; object-src
+            'self' blob:; frame-ancestors 'none'"
     middlewares-forward-auth:
       forwardAuth:
         address: "http://traefik-forward-auth:4181"


### PR DESCRIPTION
## Problem

Bitwarden web vault registration with the **"Check passwords against breaches" (HIBP)** toggle enabled fails with:

```
Refused to connect to https://api.pwnedpasswords.com/range/1ADC8 because it does not appear in the connect-src directive of the Content Security Policy.
```

The repo-wide `middlewares-secure-headers` CSP locks `connect-src` to `'self'`. Upstream Bitwarden's own rendered nginx config sets a more permissive CSP, but Traefik's `customResponseHeaders` overrides it with the strict default, breaking HIBP and any feature that relies on the same CSP allowances (Duo MFA iframes, Argon2 wasm KDF, alias generator, blob attachments).

## Fix

Adds a dedicated `middlewares-bitwarden-secure-headers` (matching the qbittorrent/plex/immich pattern) and wires `chain-no-auth-bitwarden` + `chain-auth-bitwarden` chains. The three Bitwarden routers (`bitwarden-rtr`, `bitwarden-admin-rtr`, `bitwarden-monitor`) now use these chains.

The Bitwarden CSP mirrors upstream's `nginx-config.hbs`:

- `script-src 'wasm-unsafe-eval'` — Argon2 KDF wasm module
- `connect-src https://api.pwnedpasswords.com https://api.2fa.directory https://app.simplelogin.io/api/alias/random/new`
- `img-src https://haveibeenpwned.com` — HIBP breach-result icons
- `child-src` / `frame-src` — `*.duosecurity.com` and `*.duofederal.com` for Duo MFA
- `object-src 'self' blob:` — vault attachments
- `frame-ancestors 'none'` — added on top of upstream for clickjacking protection

## Other change

Includes a value bump in `services/bitwarden/secret.sops.env` (`BW_DISABLE_USER_REGISTRATION`) staged on the branch.

## Validation

- `docker compose -f services/bitwarden/compose.yaml config --quiet` → no errors
- `yamlfmt` + `yamllint` clean on all four edited files
- SOPS decrypts cleanly: 16 keys present including the new `BW_DISABLE_USER_REGISTRATION`