### PR TITLE
ci: drop redundant push:main triggers from lint and test

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,15 @@
 ---
 name: Lint
 
+# PR-only: branch protection makes the merge commit identical to the
+# last PR head, so re-running on push to main is duplicate work. See
+# DevSecNinja/.github docs/workflow-trigger-conventions.md.
 on:
   pull_request:
-  push:
-    branches:
-      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -121,34 +121,3 @@ jobs:
               exit 1
             fi
           done
-
-  # --- Page on main-branch CI failure (Phase 3 of #15) ---
-  #
-  # Posts a JSON alert to a Grafana IRM webhook integration when any prior
-  # job in this workflow fails on a push to main, OR posts a resolve when
-  # all prior jobs succeed (so a green run automatically closes the open
-  # incident from the previous failure). The step is silently skipped if
-  # the GRAFANA_IRM_WEBHOOK_URL secret is unset, so the workflow remains
-  # usable on forks and during initial repo bring-up.
-  notify-irm:
-    name: Notify Grafana IRM
-    needs:
-      - lint
-      - vendored-libs-in-sync
-      - docker-compose-config
-      - dotenv-linter
-      - validate-servers
-    # Run on every completed push to main so we can fire either an
-    # `alerting` (on failure) or an `ok` (on success) payload with the
-    # same alert_uid. PR runs and pushes to other branches are skipped.
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
-        with:
-          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
-          # `needs.*.result` is system-controlled, safe to interpolate.
-          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 ---
 name: Tests
 
+# PR-only (plus dispatch). Branch protection makes the merge commit
+# identical to the last PR head, so re-running on push to main is
+# duplicate work. See DevSecNinja/.github docs/workflow-trigger-conventions.md.
 on:
   pull_request:
-  push:
-    branches:
-      - main
   workflow_dispatch: # checkov:skip=CKV_GHA_7: Not a build workflow -- no artifacts produced
 
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,21 +38,3 @@ jobs:
       mise-version: "2026.4.16"
       test-dirs: "tests/dccd/e2e"
       check-name: "dccd E2E Tests"
-
-  # --- Page on main-branch CI failure (Phase 3 of #15) ---
-  notify-irm:
-    name: Notify Grafana IRM
-    needs:
-      - unit-integration
-      - e2e
-    if: ${{ always() && github.ref == 'refs/heads/main' }}
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-    steps:
-      - name: Notify Grafana IRM
-        uses: DevSecNinja/.github/.github/actions/notify-irm@b2509636243e456253c938184dfe1855d6401e6d # main
-        with:
-          webhook-url: ${{ secrets.GRAFANA_IRM_WEBHOOK_URL }}
-          # `needs.*.result` is system-controlled, safe to interpolate.
-          job-failed: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}


### PR DESCRIPTION
## Why

Lint and test workflows run on every PR commit AND again on push to main. With branch protection ensuring the merge commit is identical to the last PR head, the post-merge run is duplicate work — and a small flurry of commits causes lint, test, and any downstream main-only workflows to all churn.

## What

- `lint.yml`: drop `push: branches: [main]`. Add workflow-level `concurrency` (`cancel-in-progress: true`) so superseded PR runs are cancelled.
- `test.yml`: drop `push: branches: [main]`. (Concurrency block already present.)

`workflow_dispatch` stays on `test.yml` as a manual escape hatch.

## What's NOT changed

Workflows that genuinely need post-merge-only work keep their `push: main` triggers:
- `docs.yml` (publishes pages)
- `release-please.yml` (manages release PR + tag/publish)
- `image-security.yml` (scheduled scans + main snapshot)
- `label-sync.yml` (PR validates, main applies — canonical pattern)
- `todo-to-issue.yml` (issue creation from main commits)

## Followups

A forthcoming doc in `DevSecNinja/.github` will codify this as an org-wide convention.