### PR TITLE
feat(dns): add travel subdomain as transparent local zone

### DIFF
--- a/services/adguard/config/unbound/conf.d/server-overrides.conf
+++ b/services/adguard/config/unbound/conf.d/server-overrides.conf
@@ -33,6 +33,7 @@ server:
     # Exempt subdomains from the static zone so their forward-zones can resolve them
     local-zone: "v60.${DOMAINNAME}." transparent
     local-zone: "digitalsecurity.${DOMAINNAME}." transparent
+    local-zone: "travel.${DOMAINNAME}." transparent
 
     # CA bundle for verifying upstream DoT certificates (not needed for recursive
     # resolution but kept for reference in case forward zones are re-enabled).


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does. -->

## Changes

<!-- List the key changes. -->

-

## Checklist

- [ ] Linting passes locally (`mise exec -- lefthook run pre-commit`)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Documentation updated (if applicable)
