### PR TITLE
fix(bitwarden): correct BACKUP.md link path for mkdocs strict build

### DIFF
--- a/services/bitwarden/README.md
+++ b/services/bitwarden/README.md
@@ -60,7 +60,7 @@ The `bitwarden-db-backup` sidecar (tiredofit/db-backup with s6-overlay) runs a o
 - **Storage**: Backups are written to `./backups/db-backup/` (gitignored). Old backups are cleaned up after 48 hours (`DEFAULT_CLEANUP_TIME=2880`).
 - **Network**: `network_mode: none` — the backup container has no network access.
 
-See [docs/BACKUP.md](../../docs/BACKUP.md#application-level-database-backups) for restore instructions.
+See [Backup](../BACKUP.md#application-level-database-backups) for restore instructions.
 
 ## First-Run Setup
 


### PR DESCRIPTION
The link in `services/bitwarden/README.md` to `docs/BACKUP.md` broke the strict mkdocs build merged in #328:

```
WARNING -  Doc file 'services/bitwarden.md' contains a link '../../docs/BACKUP.md#application-level-database-backups',
           but the target '../docs/BACKUP.md' is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

### Why

The README is symlinked into the docs site at `docs/services/bitwarden.md`. From that mount point, `../../docs/...` escapes the docs root, so mkdocs cannot resolve it.

### Fix

Use `../BACKUP.md`, matching the convention already used for `../ARCHITECTURE.md` and `../INFRASTRUCTURE.md` in other service READMEs (verified via grep).

```diff
-See [docs/BACKUP.md](../../docs/BACKUP.md#application-level-database-backups) for restore instructions.
+See [Backup](../BACKUP.md#application-level-database-backups) for restore instructions.
```

### Verification

`mise exec -- mkdocs build --strict` runs cleanly — no `WARNING` lines about missing link targets.