### PR TITLE
feat(dccd): show last 10 log lines from each container on deploy failure

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -604,6 +604,34 @@ record_container_restarts() {
     done <<<"${containers}"
 }
 
+# Dump the last N log lines (default 10) from every container in a compose
+# project. Used when a deploy fails to give a quick on-screen hint without
+# requiring the operator to ssh in and run `docker compose logs`.
+# Arguments: $1 = project name, $2 = (optional) line count
+dump_project_logs_tail() {
+    local project="$1"
+    local lines="${2:-10}"
+    local containers
+    containers=$(${SUDO} docker ps -a \
+        --filter "label=com.docker.compose.project=${project}" \
+        --format '{{.Names}}' 2>/dev/null) || true
+
+    if [ -z "${containers}" ]; then
+        return 0
+    fi
+
+    while IFS= read -r container; do
+        [ -z "${container}" ] && continue
+        local logs
+        logs=$(${SUDO} docker logs --tail "${lines}" "${container}" 2>&1) || true
+        if [ -z "${logs}" ]; then
+            printf '(no log output)\n' | log_data WARN "${container}: last ${lines} log lines"
+        else
+            printf '%s\n' "${logs}" | log_data WARN "${container}: last ${lines} log lines"
+        fi
+    done <<<"${containers}"
+}
+
 redeploy_truenas_apps() {
     local src_dir="${BASE_DIR}/services"
 
@@ -730,6 +758,7 @@ redeploy_truenas_apps() {
                 --abort-on-container-exit \
                 >/dev/null 2>&1; then
                 log_error "${app_name} one-shot container failed - check 'sudo docker compose --project-name ${project_name} logs' for details"
+                dump_project_logs_tail "${project_name}"
                 _DEPLOY_ERRORS=$((_DEPLOY_ERRORS + 1))
                 _DEPLOY_FAILED_APPS+=("${app_name}")
             fi
@@ -742,6 +771,7 @@ redeploy_truenas_apps() {
                     # shellcheck disable=SC2001  # multiline replace; ${var//x/y} doesn't anchor to line start
                     echo "${deploy_output}" | sed 's/^/  /'
                 fi
+                dump_project_logs_tail "${project_name}"
                 _DEPLOY_ERRORS=$((_DEPLOY_ERRORS + 1))
                 _DEPLOY_FAILED_APPS+=("${app_name}")
             fi


### PR DESCRIPTION
## Summary

When `dccd.sh` reports a deploy failure (`failed to become healthy within ${WAIT_TIMEOUT}s` or a one-shot bootstrap exits non-zero), it now dumps the last 10 lines of `docker logs` for every container in the failing compose project.

Previously the operator had to ssh into the host and run `sudo docker compose --project-name ix-<app> logs` to see why a container crash-looped. For trivial failures (missing config, bad env var, image entrypoint complaint) the answer is in the first few lines of stderr — surfacing them inline saves a round-trip.

## Changes

- New helper `dump_project_logs_tail` in [scripts/dccd.sh](scripts/dccd.sh) — uses `docker ps --filter label=com.docker.compose.project=<project>` to list all containers (running or exited) and prints `--tail 10` of their logs via `log_data WARN`.
- Called from both deploy failure paths:
    - One-shot/bootstrap project failure
    - `compose up --wait` timeout in `compose_up_wait_tolerant`

## Validation

- `mise exec -- shellcheck scripts/dccd.sh` — clean
- `mise exec -- shfmt --diff scripts/dccd.sh` — clean
- `bash -n scripts/dccd.sh` — clean
- Function smoke-tested in isolation with a fake compose-labeled container; output renders as a `WARN` log block under `<container>: last 10 log lines` with each log line indented underneath.

## Real-world trigger

This was prompted by an `openclaw` deploy that crash-looped with `Missing config. Run 'openclaw setup' or set gateway.mode=local (or pass --allow-unconfigured).` — visible immediately in `docker logs` but only after manual investigation. With this change, the same failure on a future `dccd-app <app>` invocation will print the missing-config error directly under the failure line.