### PR TITLE
fix(openclaw): pass --allow-unconfigured so gateway boots before onboarding

### DIFF
--- a/services/openclaw/compose.yaml
+++ b/services/openclaw/compose.yaml
@@ -33,6 +33,10 @@ services:
     depends_on:
       openclaw-init:
         condition: service_completed_successfully
+    # --allow-unconfigured lets the gateway start with an empty
+    # ./data/openclaw.json so first-run onboarding happens via the Control UI
+    # instead of a one-shot CLI step. After onboarding writes openclaw.json,
+    # the flag is harmless on subsequent restarts.
     command:
       - "node"
       - "dist/index.js"
@@ -41,6 +45,7 @@ services:
       - "lan"
       - "--port"
       - "18789"
+      - "--allow-unconfigured"
     env_file:
       - path: .env # Decrypted from secret.sops.env
         required: false


### PR DESCRIPTION
## Summary

Follow-up to #335. The gateway was crash-looping on first deploy:

```
[gateway] loading configuration…
[gateway] resolving authentication…
Missing config. Run `openclaw setup` or set gateway.mode=local (or pass --allow-unconfigured).
```

OpenClaw's official Docker flow runs onboarding via a one-shot `node dist/index.js onboard` invocation **before** `docker compose up -d`, which writes the initial `~/.openclaw/openclaw.json`. We don't run that step, so the persistent gateway exits because `./data/openclaw.json` doesn't exist yet.

Adding `--allow-unconfigured` lets the gateway start with an empty config. First-run onboarding then happens through the Control UI at `https://openclaw.${DOMAINNAME}` (paste `OPENCLAW_GATEWAY_TOKEN` in Settings → add the Azure OpenAI provider). On subsequent restarts the flag is a no-op because the config now exists.

## Changes

- [services/openclaw/compose.yaml](services/openclaw/compose.yaml) — append `--allow-unconfigured` to the gateway `command:` and add a comment explaining why.

## Validation

- `mise exec -- yamlfmt -lint services/openclaw/compose.yaml` — clean
- `mise exec -- yamllint services/openclaw/compose.yaml` — clean
- `docker compose -f services/openclaw/compose.yaml config --quiet` — passes