### PR TITLE
fix(dccd): propagate CONFIG_HASH through sudo so config.sha256 recreate trigger works

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -749,8 +749,8 @@ redeploy_truenas_apps() {
             # --abort-on-container-exit is incompatible with -d, which is fine — we
             # want to block until the init work is done before deploying later apps.
             log_info "${app_name} output suppressed — check 'sudo docker compose --project-name ${project_name} logs' if needed"
-            if ! ${SUDO} docker compose \
-                "${COMPOSE_PROFILE_ARGS[@]}" \
+            # shellcheck disable=SC2310  # set -e disable in `if !` is acceptable here; we handle the failure explicitly
+            if ! run_compose_command \
                 --project-name "${project_name}" \
                 --file "${compose_file}" \
                 up \
@@ -863,6 +863,11 @@ run_compose_command() {
     local -a cmd=()
     if [ -n "${SUDO}" ]; then
         cmd+=("${SUDO}")
+        # sudo's default env_reset policy strips environment variables, including
+        # CONFIG_HASH which the caller exports for ${CONFIG_HASH:-} interpolation
+        # in compose label values (config.sha256 recreate triggers). Pass it as
+        # a per-command env assignment so it reaches the docker compose process.
+        cmd+=("CONFIG_HASH=${CONFIG_HASH:-}")
     fi
     cmd+=(docker compose)
     cmd+=("${COMPOSE_PROFILE_ARGS[@]}")

--- a/tests/dccd/unit/run_compose_command.bats
+++ b/tests/dccd/unit/run_compose_command.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# Unit tests for run_compose_command()
+#
+# Verifies that:
+#   - When SUDO is unset, no sudo prefix and no env assignment are added.
+#   - When SUDO is set, sudo is prefixed AND CONFIG_HASH=<value> is passed as
+#     a per-command env assignment so it survives sudo's env_reset policy
+#     (which is what makes the config.sha256 label recreate-trigger work).
+#   - COMPOSE_OPTS word-splits into argv elements.
+
+setup() {
+    load '../helpers/common'
+    load '../helpers/mocks'
+    common_setup
+}
+
+teardown() {
+    common_teardown
+}
+
+@test "run_compose_command: no SUDO prefix when SUDO is empty" {
+    SUDO=""
+    COMPOSE_OPTS=""
+    COMPOSE_PROFILE_ARGS=()
+    # Mock both sudo and docker so we can detect which one is invoked
+    create_mock "sudo" 0 "sudo-was-called"
+    create_mock "docker" 0 "docker-direct"
+
+    CONFIG_HASH="deadbeef" run run_compose_command --version
+    assert_success
+    assert_output --partial "docker-direct"
+    refute_output --partial "sudo-was-called"
+}
+
+@test "run_compose_command: passes CONFIG_HASH via sudo when SUDO is set" {
+    # shellcheck disable=SC2034  # consumed by run_compose_command via dynamic globals
+    SUDO="sudo"
+    # shellcheck disable=SC2034
+    COMPOSE_OPTS=""
+    # shellcheck disable=SC2034
+    COMPOSE_PROFILE_ARGS=()
+    # Mock sudo to echo all its args so we can inspect the argv it would build.
+    create_mock "sudo" 0 ""
+    cat >"${MOCK_BIN}/sudo" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$@"
+MOCK
+    chmod +x "${MOCK_BIN}/sudo"
+
+    CONFIG_HASH="265b9bbe" run run_compose_command --project-name foo up
+    assert_success
+    # The first argv element must be the CONFIG_HASH=<value> env assignment,
+    # which sudo treats as a per-command env var that survives env_reset.
+    assert_line --index 0 "CONFIG_HASH=265b9bbe"
+    assert_line --index 1 "docker"
+    assert_line --index 2 "compose"
+}
+
+@test "run_compose_command: passes empty CONFIG_HASH when var is unset" {
+    # shellcheck disable=SC2034  # consumed by run_compose_command via dynamic globals
+    SUDO="sudo"
+    # shellcheck disable=SC2034
+    COMPOSE_OPTS=""
+    # shellcheck disable=SC2034
+    COMPOSE_PROFILE_ARGS=()
+    cat >"${MOCK_BIN}/sudo" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$@"
+MOCK
+    chmod +x "${MOCK_BIN}/sudo"
+
+    unset CONFIG_HASH
+    run run_compose_command up
+    assert_success
+    # Even with CONFIG_HASH unset, the assignment must be emitted (with empty
+    # value) so the absence is explicit and the call signature is consistent.
+    assert_line --index 0 "CONFIG_HASH="
+}


### PR DESCRIPTION
## Summary

The `config.sha256=${CONFIG_HASH:-}` recreate-trigger added in #356 has been silently no-op'ing for **every TrueNAS-mode app** since it merged. This PR fixes the root cause.

## Root cause

`redeploy_truenas_apps` and `redeploy_compose_file` both compute and `export CONFIG_HASH`, but invoke compose via `${SUDO} docker compose ...`. By default sudo's `env_reset` policy strips environment variables from the child process, so `CONFIG_HASH` never reaches `docker compose`. Compose then interpolated `${CONFIG_HASH:-}` in label values as the empty string.

Confirmed live on the TrueNAS host (svlnas):

```
$ sudo docker inspect adguard-unbound --format '{{index .Config.Labels "config.sha256"}}'
                  # ← empty
$ find services/adguard/config -type f | sort | xargs sha256sum | sha256sum
265b9bbe8ab08b1cb03e00197237aed965af716d272f2acb3d1b3602c6883aa6  -
```

The label was empty across deploys, so docker compose detected no change and never recreated the unbound container — even after `services/adguard/config/unbound/conf.d/a-records.conf` was edited and `dccd-all` ran successfully. This affects adguard-unbound-init, adguard-unbound, adguard-unbound-flush, and adguard.

## Fix

Pass `CONFIG_HASH` as a per-command env assignment in `run_compose_command`:

```sh
cmd+=("${SUDO}")
cmd+=("CONFIG_HASH=${CONFIG_HASH:-}")
cmd+=(docker compose)
```

`sudo VAR=value cmd` works regardless of `env_reset`/`env_keep` sudoers policy, so no host-side sudoers tweak is needed. Also routes the `_bootstrap` one-shot deploy through `run_compose_command` for consistency.

## Tests

New unit tests in `tests/dccd/unit/run_compose_command.bats`:

- No `sudo` prefix when `SUDO` is empty.
- `CONFIG_HASH=<value>` is the first argv element when `SUDO` is set.
- Empty `CONFIG_HASH` value is still emitted explicitly when the var is unset.

All 113 existing unit tests still pass.

## Verification on TrueNAS after merge

After this lands, `dccd-all` should recreate adguard-unbound exactly once (label transitions from empty → `265b9bbe…`). Then:

```sh
sudo docker inspect adguard-unbound --format '{{index .Config.Labels "config.sha256"}}'
# Expected: 265b9bbe8ab08b1cb03e00197237aed965af716d272f2acb3d1b3602c6883aa6

sudo docker exec adguard-unbound drill -p 5335 @127.0.0.1 openclaw.${DOMAINNAME} | grep -E 'rcode|ANSWER'
# Expected: rcode: NOERROR + the ${IP_SVLNAS} answer
```