### PR TITLE
fix(openclaw): tolerate chown failures in init container

### DIFF
--- a/services/openclaw/compose.yaml
+++ b/services/openclaw/compose.yaml
@@ -23,7 +23,7 @@ services:
       - "sh"
       - "-c"
       - |-
-        chown -Rv 3127:3127 /data
+        chown -Rv 3127:3127 /data || true
     volumes:
       - ./data:/data
 


### PR DESCRIPTION
## Summary

`openclaw-init` chown was aborting on the second+ deploy with `chown: /data: Permission denied` (see deploy log below), even though POSIX permissions on the dataset look fine (`acltype=posix`, root with `CAP_CHOWN`, target dir is `truenas_admin:truenas_admin 770`).

This matches the same ZFS quirk we already work around in `alloy`, `mosquitto`, `matter-server`, and `wmbusmeters`: append `|| true` so a single chown failure on a populated `./data` subtree doesn't kill the entire init step.

## Observed failure (svlnas)

```
WARN [dccd] │ changed ownership of '/data' to 3127:3127
WARN [dccd] │ changed ownership of '/data' to 3127:3127
WARN [dccd] │ changed ownership of '/data' to 3127:3127
WARN [dccd] │ changed ownership of '/data' to 3127:3127
WARN [dccd] │ changed ownership of '/data' to 3127:3127
WARN [dccd] │ chown: /data: Permission denied
```

5 successful chowns then an abort — repeatable across deploys. Aligns with the documented "ZFS tolerance" pattern in user memory.

## Diff

One-line: append `|| true` to the chown in the init container, matching the other ZFS-tolerant init scripts in the repo.

## Validation

- `docker compose -f services/openclaw/compose.yaml config --quiet` passes (only the expected unset `${DOMAINNAME}` / `${OPENCLAW_GATEWAY_TOKEN}` warnings).
- `yamlfmt -lint` and `yamllint` clean.