### PR TITLE
fix(dccd): use env(1) wrapper for CONFIG_HASH (sudoers SETENV not granted on TrueNAS)

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -869,6 +869,13 @@ run_compose_command() {
         # a per-command env assignment so it reaches the docker compose process.
         cmd+=("CONFIG_HASH=${CONFIG_HASH:-}")
     fi
+    # Wrap the compose invocation in `env CONFIG_HASH=...` so the variable
+    # reaches docker compose for ${CONFIG_HASH:-} interpolation in compose
+    # labels (config.sha256 recreate triggers). Direct sudo VAR=value passing
+    # requires the SETENV sudoers tag, which TrueNAS-style sudoers does not
+    # grant; `sudo env VAR=value cmd` bypasses that check because the assignment
+    # is argv to `env`, not a sudo-level env override.
+    cmd+=(env "CONFIG_HASH=${CONFIG_HASH:-}")
     cmd+=(docker compose)
     cmd+=("${COMPOSE_PROFILE_ARGS[@]}")
     if [ -n "${COMPOSE_OPTS}" ]; then

--- a/tests/dccd/unit/run_compose_command.bats
+++ b/tests/dccd/unit/run_compose_command.bats
@@ -2,11 +2,12 @@
 # Unit tests for run_compose_command()
 #
 # Verifies that:
-#   - When SUDO is unset, no sudo prefix and no env assignment are added.
-#   - When SUDO is set, sudo is prefixed AND CONFIG_HASH=<value> is passed as
-#     a per-command env assignment so it survives sudo's env_reset policy
-#     (which is what makes the config.sha256 label recreate-trigger work).
-#   - COMPOSE_OPTS word-splits into argv elements.
+#   - When SUDO is unset, no sudo prefix is added.
+#   - When SUDO is set, sudo is the first argv element.
+#   - In both cases the compose invocation is wrapped in `env CONFIG_HASH=...`
+#     so the value reaches docker compose for ${CONFIG_HASH:-} interpolation
+#     in compose labels (config.sha256 recreate triggers). This sidesteps
+#     sudoers SETENV restrictions on TrueNAS-style hosts.
 
 setup() {
     load '../helpers/common'
@@ -18,21 +19,27 @@ teardown() {
     common_teardown
 }
 
-@test "run_compose_command: no SUDO prefix when SUDO is empty" {
+@test "run_compose_command: no SUDO prefix when SUDO is empty; env wrapper present" {
     SUDO=""
+    # shellcheck disable=SC2034
     COMPOSE_OPTS=""
+    # shellcheck disable=SC2034
     COMPOSE_PROFILE_ARGS=()
-    # Mock both sudo and docker so we can detect which one is invoked
+    # Mock env so we can capture the argv it sees and confirm sudo is NOT in it.
+    cat >"${MOCK_BIN}/env" <<'MOCK'
+#!/bin/bash
+printf 'env-args:%s\n' "$@"
+MOCK
+    chmod +x "${MOCK_BIN}/env"
     create_mock "sudo" 0 "sudo-was-called"
-    create_mock "docker" 0 "docker-direct"
 
     CONFIG_HASH="deadbeef" run run_compose_command --version
     assert_success
-    assert_output --partial "docker-direct"
     refute_output --partial "sudo-was-called"
+    assert_line --index 0 "env-args:CONFIG_HASH=deadbeef"
 }
 
-@test "run_compose_command: passes CONFIG_HASH via sudo when SUDO is set" {
+@test "run_compose_command: passes CONFIG_HASH via env wrapper when SUDO is set" {
     # shellcheck disable=SC2034  # consumed by run_compose_command via dynamic globals
     SUDO="sudo"
     # shellcheck disable=SC2034
@@ -40,7 +47,6 @@ teardown() {
     # shellcheck disable=SC2034
     COMPOSE_PROFILE_ARGS=()
     # Mock sudo to echo all its args so we can inspect the argv it would build.
-    create_mock "sudo" 0 ""
     cat >"${MOCK_BIN}/sudo" <<'MOCK'
 #!/bin/bash
 printf '%s\n' "$@"
@@ -49,11 +55,12 @@ MOCK
 
     CONFIG_HASH="265b9bbe" run run_compose_command --project-name foo up
     assert_success
-    # The first argv element must be the CONFIG_HASH=<value> env assignment,
-    # which sudo treats as a per-command env var that survives env_reset.
-    assert_line --index 0 "CONFIG_HASH=265b9bbe"
-    assert_line --index 1 "docker"
-    assert_line --index 2 "compose"
+    # `env CONFIG_HASH=value` runs `env` as the command, so sudoers SETENV
+    # restrictions don't apply (it's argv to env, not a sudo-level env override).
+    assert_line --index 0 "env"
+    assert_line --index 1 "CONFIG_HASH=265b9bbe"
+    assert_line --index 2 "docker"
+    assert_line --index 3 "compose"
 }
 
 @test "run_compose_command: passes empty CONFIG_HASH when var is unset" {
@@ -72,7 +79,8 @@ MOCK
     unset CONFIG_HASH
     run run_compose_command up
     assert_success
-    # Even with CONFIG_HASH unset, the assignment must be emitted (with empty
-    # value) so the absence is explicit and the call signature is consistent.
-    assert_line --index 0 "CONFIG_HASH="
+    # Even with CONFIG_HASH unset, the wrapper must be emitted with empty value
+    # so the call signature stays consistent.
+    assert_line --index 0 "env"
+    assert_line --index 1 "CONFIG_HASH="
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #369. That PR's approach (`sudo CONFIG_HASH=value docker compose ...`) immediately broke deploys on the TrueNAS host because TrueNAS sudoers does not grant the `SETENV` tag:

```
ERROR [dccd] adguard failed to become healthy within 120s
  sudo: sorry, you are not allowed to set the following environment variables: CONFIG_HASH
```

This PR uses `env(1)` as a wrapper instead. `sudo env CONFIG_HASH=value docker compose ...` works on any sudoers configuration because the assignment is argv to the `env` binary, not a sudo-level env override — so sudo's SETENV check never fires. The result is identical: `docker compose` sees `CONFIG_HASH` in its environment and interpolates the `config.sha256=${CONFIG_HASH:-}` label correctly.

## Diff vs main

- `run_compose_command`: replace the inline `CONFIG_HASH=...` argument with `env "CONFIG_HASH=..."` placed before `docker compose`. The wrapper is now applied unconditionally (not gated on `${SUDO}`), so the same logic works on rootful and rootless hosts.
- `tests/dccd/unit/run_compose_command.bats`: update assertions to verify the new argv shape.

## Tests

```
$ mise exec -- bats tests/dccd/unit/run_compose_command.bats
ok 1 run_compose_command: no SUDO prefix when SUDO is empty; env wrapper present
ok 2 run_compose_command: passes CONFIG_HASH via env wrapper when SUDO is set
ok 3 run_compose_command: passes empty CONFIG_HASH when var is unset
```

`shellcheck` and `shfmt --diff` clean on both files.

## Why this is correct

`env(1)` is POSIX, present on every TrueNAS Scale image, and its `KEY=VALUE` pre-args are evaluated *after* sudo has executed it — there's no sudoers gate to satisfy. Compose receives the variable in its environment exactly as if we'd `export`ed it.

## Verification post-merge (svlnas)

```sh
# Should recreate the unbound containers exactly once on next dccd-all.
sudo docker inspect adguard-unbound \
  --format '{{index .Config.Labels "config.sha256"}}'
# Expected: 265b9bbe8ab08b1cb03e00197237aed965af716d272f2acb3d1b3602c6883aa6
```