### PR TITLE
feat(dccd): warn instead of error on uncommitted changes when --force is set

### DIFF
--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -1121,8 +1121,13 @@ update_compose_files() {
         # Check for uncommitted local changes
         uncommitted_changes=$(git "${GIT_OPTS[@]}" status --porcelain)
         if [ -n "${uncommitted_changes}" ]; then
-            log_error "Uncommitted changes detected in ${dir}, exiting..."
-            exit 1
+            if [ "${FORCE}" -eq 1 ]; then
+                log_warn "Uncommitted changes detected in ${dir}, continuing anyway (force mode)"
+                log_warn "Note: a subsequent 'git pull' may still fail if the working tree conflicts with incoming commits"
+            else
+                log_error "Uncommitted changes detected in ${dir}, exiting..."
+                exit 1
+            fi
         fi
 
         # Ensure we are on the expected branch before comparing hashes or pulling


### PR DESCRIPTION
## Summary

`--force` was meant to power through staleness checks, but the uncommitted-changes guard still aborted hard with `Uncommitted changes detected in <dir>, exiting...`. That defeats the operator workflow of "I edited a compose file on the host to test something, redeploy with `--force`".

This PR flips the uncommitted-changes guard to a WARN under `--force`. Without `--force` the behaviour is unchanged (hard error and `exit 1`).

A subsequent `git pull` may still fail if the dirty working tree conflicts with incoming commits — the warning calls this out so the operator isn't surprised.

## Repro

```
$ dccd-app openclaw --force
...
2026-05-04 08:22:00 INFO   [dccd] Force mode enabled, will redeploy regardless of hash match
2026-05-04 08:22:01 ERROR  [dccd] Uncommitted changes detected in /mnt/vm-pool/apps, exiting...
```

After this PR:

```
2026-05-04 08:22:01 WARN   [dccd] Uncommitted changes detected in /mnt/vm-pool/apps, continuing anyway (force mode)
2026-05-04 08:22:01 WARN   [dccd] Note: a subsequent 'git pull' may still fail if the working tree conflicts with incoming commits
```

## Diff

7-line change in `pull_changes` (only branch added is `if [ "${FORCE}" -eq 1 ]; then ...`). `shellcheck` and `shfmt --diff` clean.