### PR TITLE
fix(dccd): use --env-file for CONFIG_HASH instead of sudo env wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ site/
 *.key
 secret.env
 .env
+.config-hash.env
 .decrypted~*
 
 # Exclude directories that Git might not have permissions to

--- a/scripts/dccd.sh
+++ b/scripts/dccd.sh
@@ -3,7 +3,9 @@
 # Usage in TrueNAS Scale:
 #   Command: bash /mnt/vm-pool/apps/scripts/dccd.sh -d /mnt/vm-pool/apps -x shared -t -f
 #   Cron:    bash /mnt/vm-pool/apps/scripts/dccd.sh -d /mnt/vm-pool/apps -x shared -t -q
-#   Run As User: truenas_admin (requires passwordless sudo for /usr/bin/docker)
+#   Run As User: truenas_admin (requires passwordless sudo for two commands:
+#                  /usr/bin/docker
+#                  /usr/bin/cat /root/.docker/config.json)
 #   Unselect 'Hide Standard Output' and 'Hide Standard Error'
 
 set -euo pipefail
@@ -496,6 +498,36 @@ get_config_watch_path() {
         sed 's/.*config\.watch=//' | tr -d '"'"'" | sed 's/[[:space:]]*$//' || true
 }
 
+# Write CONFIG_HASH into a dedicated per-app env file (.config-hash.env) for
+# docker compose ${CONFIG_HASH:-} variable interpolation. We can't pass the
+# variable through `sudo`, which strips env vars (env_reset) and would prompt
+# for a password under TrueNAS-style NOPASSWD rules that grant neither SETENV
+# nor a NOPASSWD entry for /usr/bin/env. We also can't append to the regular
+# .env file, since that's owned by the sops-decryption step and would mix
+# concerns.
+#
+# Compose's --env-file flag is used by run_compose_command() to load this file
+# for variable interpolation. Note: --env-file disables compose's automatic
+# loading of .env, so when both files exist run_compose_command() passes both
+# --env-file flags explicitly (compose merges them, later wins).
+#
+# Side effect: sets the global _CONFIG_HASH_ENV_FILE to the file path so
+# run_compose_command() can read it without an extra argument. Cleared by the
+# caller after the deploy completes.
+#
+# Arguments:
+#   $1  app_dir  — absolute path to the app's service directory
+#   $2  hash     — the hash value to write (may be empty)
+write_config_hash_env() {
+    local app_dir="$1"
+    local hash="${2:-}"
+    local hash_file="${app_dir}/.config-hash.env"
+
+    printf 'CONFIG_HASH=%s\n' "${hash}" >"${hash_file}"
+    chmod 600 "${hash_file}"
+    _CONFIG_HASH_ENV_FILE="${hash_file}"
+}
+
 # Returns sorted lines of "<service>=<image-reference>" for all containers in a compose project.
 # Uses docker inspect on container IDs for reliable image info (including digest).
 # Includes stopped/exited containers (-a) so one-shot services (e.g. backup sidecars) are
@@ -720,6 +752,8 @@ redeploy_truenas_apps() {
         config_watch=$(get_config_watch_path "${git_compose}")
         CONFIG_HASH=$(compute_config_hash "${BASE_DIR}/services/${app_name}" "${config_watch}")
         export CONFIG_HASH
+        # Persist CONFIG_HASH to .env for compose interpolation; see write_config_hash_env.
+        write_config_hash_env "${BASE_DIR}/services/${app_name}" "${CONFIG_HASH}"
 
         # Capture image state before pulling so we can report what changed
         local img_before
@@ -863,20 +897,31 @@ run_compose_command() {
     local -a cmd=()
     if [ -n "${SUDO}" ]; then
         cmd+=("${SUDO}")
-        # sudo's default env_reset policy strips environment variables, including
-        # CONFIG_HASH which the caller exports for ${CONFIG_HASH:-} interpolation
-        # in compose label values (config.sha256 recreate triggers). Pass it as
-        # a per-command env assignment so it reaches the docker compose process.
-        cmd+=("CONFIG_HASH=${CONFIG_HASH:-}")
     fi
-    # Wrap the compose invocation in `env CONFIG_HASH=...` so the variable
-    # reaches docker compose for ${CONFIG_HASH:-} interpolation in compose
-    # labels (config.sha256 recreate triggers). Direct sudo VAR=value passing
-    # requires the SETENV sudoers tag, which TrueNAS-style sudoers does not
-    # grant; `sudo env VAR=value cmd` bypasses that check because the assignment
-    # is argv to `env`, not a sudo-level env override.
-    cmd+=(env "CONFIG_HASH=${CONFIG_HASH:-}")
+    # CONFIG_HASH is NOT passed via the environment here. sudo strips env vars
+    # by default (env_reset), and TrueNAS-style NOPASSWD rules grant neither
+    # SETENV (needed for `sudo VAR=val cmd`) nor a NOPASSWD entry for
+    # /usr/bin/env (needed for `sudo env VAR=val cmd`). Either workaround would
+    # cause sudo to prompt for a password, breaking unattended cron deploys.
+    # Instead, the caller writes CONFIG_HASH into a dedicated .config-hash.env
+    # file via write_config_hash_env() and exposes its path through the
+    # _CONFIG_HASH_ENV_FILE global. We pass it to compose with --env-file so
+    # ${CONFIG_HASH:-} interpolation in labels resolves correctly.
+    #
+    # --env-file replaces compose's automatic loading of .env in the project
+    # directory, so when both files exist we pass both: --env-file <project>/.env
+    # is mentioned first, then --env-file <project>/.config-hash.env, and
+    # compose merges them (later wins, which lets CONFIG_HASH override anything
+    # accidentally set in .env).
     cmd+=(docker compose)
+    if [ -n "${_CONFIG_HASH_ENV_FILE:-}" ]; then
+        local hash_dir
+        hash_dir=$(dirname "${_CONFIG_HASH_ENV_FILE}")
+        if [ -f "${hash_dir}/.env" ]; then
+            cmd+=(--env-file "${hash_dir}/.env")
+        fi
+        cmd+=(--env-file "${_CONFIG_HASH_ENV_FILE}")
+    fi
     cmd+=("${COMPOSE_PROFILE_ARGS[@]}")
     if [ -n "${COMPOSE_OPTS}" ]; then
         # Word-split is intentional: COMPOSE_OPTS is a controlled CLI flag (-o)
@@ -978,6 +1023,8 @@ redeploy_compose_file() {
     config_watch=$(get_config_watch_path "${file}" "${extra_files[@]+"${extra_files[@]}"}")
     CONFIG_HASH=$(compute_config_hash "${app_dir}" "${config_watch}")
     export CONFIG_HASH
+    # Persist CONFIG_HASH to .env for compose interpolation; see write_config_hash_env.
+    write_config_hash_env "${app_dir}" "${CONFIG_HASH}"
 
     # Pull images unless NO_PULL is set
     if [ "${NO_PULL}" -eq 0 ]; then

--- a/tests/dccd/unit/run_compose_command.bats
+++ b/tests/dccd/unit/run_compose_command.bats
@@ -4,10 +4,10 @@
 # Verifies that:
 #   - When SUDO is unset, no sudo prefix is added.
 #   - When SUDO is set, sudo is the first argv element.
-#   - In both cases the compose invocation is wrapped in `env CONFIG_HASH=...`
-#     so the value reaches docker compose for ${CONFIG_HASH:-} interpolation
-#     in compose labels (config.sha256 recreate triggers). This sidesteps
-#     sudoers SETENV restrictions on TrueNAS-style hosts.
+#   - When _CONFIG_HASH_ENV_FILE is set, --env-file flags are appended so
+#     compose can interpolate ${CONFIG_HASH:-} in labels. This avoids passing
+#     CONFIG_HASH through sudo's environment, which sudoers SETENV restrictions
+#     on TrueNAS-style hosts would block (causing a password prompt).
 
 setup() {
     load '../helpers/common'
@@ -19,68 +19,122 @@ teardown() {
     common_teardown
 }
 
-@test "run_compose_command: no SUDO prefix when SUDO is empty; env wrapper present" {
+@test "run_compose_command: no SUDO prefix when SUDO is empty" {
     SUDO=""
     # shellcheck disable=SC2034
     COMPOSE_OPTS=""
     # shellcheck disable=SC2034
     COMPOSE_PROFILE_ARGS=()
-    # Mock env so we can capture the argv it sees and confirm sudo is NOT in it.
-    cat >"${MOCK_BIN}/env" <<'MOCK'
+    # shellcheck disable=SC2034
+    _CONFIG_HASH_ENV_FILE=""
+    cat >"${MOCK_BIN}/docker" <<'MOCK'
 #!/bin/bash
-printf 'env-args:%s\n' "$@"
+printf 'docker-args:%s\n' "$@"
 MOCK
-    chmod +x "${MOCK_BIN}/env"
+    chmod +x "${MOCK_BIN}/docker"
     create_mock "sudo" 0 "sudo-was-called"
 
-    CONFIG_HASH="deadbeef" run run_compose_command --version
+    run run_compose_command --version
     assert_success
     refute_output --partial "sudo-was-called"
-    assert_line --index 0 "env-args:CONFIG_HASH=deadbeef"
+    assert_line --index 0 "docker-args:compose --version"
 }
 
-@test "run_compose_command: passes CONFIG_HASH via env wrapper when SUDO is set" {
+@test "run_compose_command: prepends sudo when SUDO is set" {
     # shellcheck disable=SC2034  # consumed by run_compose_command via dynamic globals
     SUDO="sudo"
     # shellcheck disable=SC2034
     COMPOSE_OPTS=""
     # shellcheck disable=SC2034
     COMPOSE_PROFILE_ARGS=()
-    # Mock sudo to echo all its args so we can inspect the argv it would build.
+    # shellcheck disable=SC2034
+    _CONFIG_HASH_ENV_FILE=""
     cat >"${MOCK_BIN}/sudo" <<'MOCK'
 #!/bin/bash
 printf '%s\n' "$@"
 MOCK
     chmod +x "${MOCK_BIN}/sudo"
 
-    CONFIG_HASH="265b9bbe" run run_compose_command --project-name foo up
+    run run_compose_command --project-name foo up
     assert_success
-    # `env CONFIG_HASH=value` runs `env` as the command, so sudoers SETENV
-    # restrictions don't apply (it's argv to env, not a sudo-level env override).
-    assert_line --index 0 "env"
-    assert_line --index 1 "CONFIG_HASH=265b9bbe"
-    assert_line --index 2 "docker"
-    assert_line --index 3 "compose"
+    # No `env VAR=...` wrapping — sudoers SETENV restrictions on TrueNAS-style
+    # hosts would block that. CONFIG_HASH is passed via --env-file instead
+    # (when _CONFIG_HASH_ENV_FILE is set, see other tests).
+    assert_line --index 0 "docker"
+    assert_line --index 1 "compose"
 }
 
-@test "run_compose_command: passes empty CONFIG_HASH when var is unset" {
-    # shellcheck disable=SC2034  # consumed by run_compose_command via dynamic globals
-    SUDO="sudo"
+@test "run_compose_command: appends --env-file for hash file only when no .env exists" {
+    # shellcheck disable=SC2034
+    SUDO=""
     # shellcheck disable=SC2034
     COMPOSE_OPTS=""
     # shellcheck disable=SC2034
     COMPOSE_PROFILE_ARGS=()
-    cat >"${MOCK_BIN}/sudo" <<'MOCK'
+    local app_dir="${BATS_TEST_TMPDIR}/app-no-env"
+    mkdir -p "${app_dir}"
+    printf 'CONFIG_HASH=abc123\n' >"${app_dir}/.config-hash.env"
+    # shellcheck disable=SC2034
+    _CONFIG_HASH_ENV_FILE="${app_dir}/.config-hash.env"
+    cat >"${MOCK_BIN}/docker" <<'MOCK'
 #!/bin/bash
 printf '%s\n' "$@"
 MOCK
-    chmod +x "${MOCK_BIN}/sudo"
+    chmod +x "${MOCK_BIN}/docker"
 
-    unset CONFIG_HASH
-    run run_compose_command up
+    run run_compose_command up -d
     assert_success
-    # Even with CONFIG_HASH unset, the wrapper must be emitted with empty value
-    # so the call signature stays consistent.
-    assert_line --index 0 "env"
-    assert_line --index 1 "CONFIG_HASH="
+    assert_line --index 0 "compose"
+    assert_line --index 1 "--env-file"
+    assert_line --index 2 "${app_dir}/.config-hash.env"
+    # No --env-file for .env (it does not exist)
+    refute_output --partial "${app_dir}/.env"
+}
+
+@test "run_compose_command: appends both --env-file flags when .env and hash file exist" {
+    # shellcheck disable=SC2034
+    SUDO=""
+    # shellcheck disable=SC2034
+    COMPOSE_OPTS=""
+    # shellcheck disable=SC2034
+    COMPOSE_PROFILE_ARGS=()
+    local app_dir="${BATS_TEST_TMPDIR}/app-with-env"
+    mkdir -p "${app_dir}"
+    printf 'SECRET=value\n' >"${app_dir}/.env"
+    printf 'CONFIG_HASH=abc123\n' >"${app_dir}/.config-hash.env"
+    # shellcheck disable=SC2034
+    _CONFIG_HASH_ENV_FILE="${app_dir}/.config-hash.env"
+    cat >"${MOCK_BIN}/docker" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$@"
+MOCK
+    chmod +x "${MOCK_BIN}/docker"
+
+    run run_compose_command up -d
+    assert_success
+    assert_line --index 0 "compose"
+    # .env comes first, hash file second (later wins on key conflicts)
+    assert_line --index 1 "--env-file"
+    assert_line --index 2 "${app_dir}/.env"
+    assert_line --index 3 "--env-file"
+    assert_line --index 4 "${app_dir}/.config-hash.env"
+}
+
+@test "run_compose_command: no --env-file when _CONFIG_HASH_ENV_FILE is unset" {
+    # shellcheck disable=SC2034
+    SUDO=""
+    # shellcheck disable=SC2034
+    COMPOSE_OPTS=""
+    # shellcheck disable=SC2034
+    COMPOSE_PROFILE_ARGS=()
+    unset _CONFIG_HASH_ENV_FILE
+    cat >"${MOCK_BIN}/docker" <<'MOCK'
+#!/bin/bash
+printf '%s\n' "$@"
+MOCK
+    chmod +x "${MOCK_BIN}/docker"
+
+    run run_compose_command --version
+    assert_success
+    refute_output --partial "--env-file"
 }


### PR DESCRIPTION
## Problem

After PR #371, `dccd.sh` running under TrueNAS cron started prompting for a sudo password on every deploy:

```
2026-05-04 14:17:14 STATE  [dccd] Starting containers for _bootstrap
[sudo] password for truenas_admin:
2026-05-04 14:17:17 ERROR  [dccd] _bootstrap one-shot container failed
```

## Root cause

`run_compose_command` was passing `CONFIG_HASH=...` across the sudo boundary. Three approaches were tried; all of them prompt for a password under TrueNAS-style NOPASSWD rules:

| Approach | Why it fails on TrueNAS |
| --- | --- |
| `sudo CONFIG_HASH=val docker compose ...` (#369) | Requires the `SETENV` sudoers tag, which the TrueNAS UI does not grant |
| `sudo env CONFIG_HASH=val docker compose ...` (#371) | Requires `/usr/bin/env` in the NOPASSWD command list, which the TrueNAS UI does not grant |
| Exporting `CONFIG_HASH` and relying on sudo to forward it | sudo's default `env_reset` policy strips it |

Verified on the host:

```sh
$ sudo CONFIG_HASH=test docker compose version
sudo: sorry, you are not allowed to set the following environment variables: CONFIG_HASH
$ sudo env CONFIG_HASH=test docker compose version
[sudo] password for truenas_admin:
sudo: a password is required
```

## Fix

Stop passing `CONFIG_HASH` through the environment entirely. Instead:

1. New helper `write_config_hash_env()` writes `CONFIG_HASH=<value>` into a per-app `.config-hash.env` file (mode 0600) and exposes its path through the `_CONFIG_HASH_ENV_FILE` global.
2. `run_compose_command()` passes the file to compose with `--env-file` so `${CONFIG_HASH:-}` interpolation in compose labels resolves correctly.
3. Because `--env-file` replaces compose's automatic loading of `.env`, both files are passed when both exist (`--env-file <project>/.env --env-file <project>/.config-hash.env` — later wins).

A separate `.config-hash.env` (rather than appending to `.env`) keeps concerns isolated: the SOPS-decrypted `.env` is owned by the decrypt step and rewritten on every deploy.

## Required NOPASSWD entries (unchanged)

The TrueNAS `truenas_admin` user still needs both:

- `/usr/bin/docker`
- `/usr/bin/cat /root/.docker/config.json` (for `check_dhi_login()`)

The header comment in `dccd.sh` is now updated to list both.

## Other changes

- `.gitignore`: add `.config-hash.env`
- BATS unit tests: covered by 5 new cases in `tests/dccd/unit/run_compose_command.bats` (no SUDO, with SUDO, only hash file, both `.env` and hash file, `_CONFIG_HASH_ENV_FILE` unset).

## Verification

- `shellcheck scripts/dccd.sh` — clean
- `shfmt --diff scripts/dccd.sh` — clean
- `bats tests/dccd/unit/` — 119 passing, 0 failing

Supersedes #371.