### PR TITLE
chore: sync CODEOWNERS bot-bump exclusions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,52 +30,103 @@
 /.ruby-version
 
 # Node / JS
+/package.json
 /package-lock.json
 /yarn.lock
 /pnpm-lock.yaml
 /npm-shrinkwrap.json
+**/package.json
 **/package-lock.json
 **/yarn.lock
 **/pnpm-lock.yaml
 
 # Python
+/pyproject.toml
 /poetry.lock
 /uv.lock
 /Pipfile.lock
 /requirements*.txt
+**/pyproject.toml
 **/poetry.lock
 **/uv.lock
 **/Pipfile.lock
 **/requirements*.txt
 
 # Go
+/go.mod
 /go.sum
+**/go.mod
 **/go.sum
 
 # Rust
+/Cargo.toml
 /Cargo.lock
+**/Cargo.toml
 **/Cargo.lock
 
 # Ruby
+/Gemfile
 /Gemfile.lock
+**/Gemfile
 **/Gemfile.lock
 
 # PHP
+/composer.json
 /composer.lock
+**/composer.json
 **/composer.lock
 
 # Elixir
+/mix.exs
 /mix.lock
+**/mix.exs
 **/mix.lock
 
 # Nix
+/flake.nix
 /flake.lock
+**/flake.nix
 **/flake.lock
 
 # Terraform / OpenTofu
 /.terraform.lock.hcl
 **/.terraform.lock.hcl
 
+# Container images (Dockerfile / Compose)
+/Dockerfile
+**/Dockerfile
+**/Dockerfile.*
+**/*.Dockerfile
+/docker-compose.yml
+/docker-compose.yaml
+**/docker-compose*.yml
+**/docker-compose*.yaml
+/compose.yml
+/compose.yaml
+**/compose*.yml
+**/compose*.yaml
+
+# GitHub Actions metadata (reusable workflow files already cleared above)
+/workflow-templates/*.yml
+/workflow-templates/*.yaml
+/action.yml
+/action.yaml
+**/action.yml
+**/action.yaml
+
+# pre-commit hooks
+/.pre-commit-config.yaml
+/.pre-commit-config.yml
+
 # Dev containers
+/.devcontainer/devcontainer.json
+/.devcontainer.json
+**/devcontainer.json
 /.devcontainer/devcontainer-lock.json
 **/devcontainer-lock.json
+
+# Renovate custom-managed scripts (log.sh release pin, SOPS version)
+**/dccd.sh
+**/build-log-sh-release.sh
+**/install-log-sh.sh
+**/update-log-sh.sh

--- a/.github/workflows/config-sync.yml
+++ b/.github/workflows/config-sync.yml
@@ -7,63 +7,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
   contents: write
   pull-requests: write
 
 jobs:
   sync:
-    uses: DevSecNinja/.github/.github/workflows/config-sync.yml@b9b199e6ef225c6e8da6ded4da2cf2c492f6d94e # main
+    uses: DevSecNinja/.github/.github/workflows/config-sync.yml@c1725a7573e1cb5277889d925901b477ee814352 # v1.7.0
     permissions:
       contents: write
       pull-requests: write
-
-  dispatch-pr-ci:
-    name: Dispatch PR CI
-    needs: sync
-    runs-on: ubuntu-24.04
-    permissions:
-      actions: write
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Dispatch Lint and Tests for config-sync PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          CI_WORKFLOWS: |-
-            lint.yml
-            test.yml
-        run: |-
-          set -euo pipefail
-
-          if ! pr_heads=$(gh pr list \
-            --state open \
-            --label config-sync \
-            --json headRefName \
-            --jq '.[].headRefName'); then
-            echo "::error::Failed to list open config-sync PRs."
-            exit 1
-          fi
-
-          head_refs=()
-          while IFS= read -r head_ref; do
-            [ -n "${head_ref}" ] && head_refs+=("${head_ref}")
-          done <<< "${pr_heads}"
-
-          if [ "${#head_refs[@]}" -eq 0 ]; then
-            echo "No open config-sync PR found; skipping CI dispatch."
-            exit 0
-          fi
-
-          ci_workflows=()
-          while IFS= read -r workflow; do
-            [ -n "${workflow}" ] && ci_workflows+=("${workflow}")
-          done <<< "${CI_WORKFLOWS}"
-
-          for head_ref in "${head_refs[@]}"; do
-            for workflow in "${ci_workflows[@]}"; do
-              echo "Dispatching ${workflow} for ${head_ref}..."
-              gh workflow run "${workflow}" --ref "${head_ref}"
-            done
-          done


### PR DESCRIPTION
Sync `.github/CODEOWNERS` bot-bump exclusions to match the canonical file in [DevSecNinja/.github](https://github.com/DevSecNinja/.github/tree/main/config-sync/files/.github/CODEOWNERS).

The expanded manifest/container/actions/pre-commit/devcontainer/renovate exclusions (central commit `df892204`, 2026-06-12) were missing here, so @DevSecNinja kept getting requested as a reviewer on routine bot bumps.

Also adds/bumps the `config-sync` caller workflow to **v1.7.0** so future syncs propagate automatically (weekly + manual dispatch).