### PR TITLE
fix(renovate): set internalChecksFilter to strict

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,4 +13,10 @@
     "github>DevSecNinja/.github//.renovate/packageRules.json5",
     "github>DevSecNinja/.github//.renovate/semanticCommits.json5",
   ],
+  // Filter out versions still inside their minimumReleaseAge soak so Renovate
+  // proposes the highest already-soaked version instead of parking the update
+  // on the newest (still-pending) release. Without this, frequently-releasing
+  // images (e.g. traefik-forward-auth) stay stuck under "Pending Status Checks"
+  // and their PRs are never created. See issue #115.
+  internalChecksFilter: "strict",
 }


### PR DESCRIPTION
## Problem

Container updates for frequently-releasing images never turn into PRs. They sit indefinitely under the dependency dashboard's **"Pending Status Checks"** section (see #115). Example: `ghcr.io/italypaleale/traefik-forward-auth` has been pinned at `4.8.0` since #42 (2026-03-29) while `4.9`–`4.13` shipped.

## Root cause

Investigating a sibling stuck the same way (a leftover `renovate/lscr.io-linuxserver-socket-proxy-3.x` branch from 2026-04-04):

- All **15 required CI checks pass** on the branch.
- The only pending status is Renovate's internal `renovate/stability-days` → _"Updates have not met minimum release age requirement"_.

Renovate holds PR creation while that internal soak check is pending. The dashboard offers `4.8.0 ➔ 4.13.0` — the newest release (2 days old, still inside the 14-day `minimumReleaseAge` soak) — instead of the highest **already-soaked** version (`4.12.0`, released 2026-07-06). That's `internalChecksFilter: "none"` behaviour, so the check never clears for fast movers and no PR is ever created.

## Fix

Set `internalChecksFilter: "strict"` so Renovate filters out still-pending versions and proposes the highest non-pending version, which then auto-merges once soaked. The 14-day supply-chain soak is preserved.

> Note: The durable fix also lives in the shared presets — see DevSecNinja/.github#284. This local override gives immediate effect for this repo.

Refs #115