### PR TITLE
fix(ci): lower stale image threshold to 90 days

### DIFF
--- a/.github/workflows/image-security.yml
+++ b/.github/workflows/image-security.yml
@@ -14,9 +14,9 @@ on:
     # threshold_days only affects a date comparison for issue creation.
     inputs:
       threshold_days:
-        description: "Flag images older than this many days (default: 365)"
+        description: "Flag images older than this many days (default: 90)"
         required: false
-        default: "365"
+        default: "90"
         type: string
 
 permissions:
@@ -45,7 +45,7 @@ jobs:
       - name: Check image ages and open issues for stale images
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          THRESHOLD_DAYS: ${{ inputs.threshold_days || '365' }}
+          THRESHOLD_DAYS: ${{ inputs.threshold_days || '90' }}
         run: bash scripts/gha-image-age-check.sh
 
   trivy-image-scan:


### PR DESCRIPTION
## What

Lower `THRESHOLD_DAYS` in `image-security.yml` from **365 → 90** (both the `workflow_dispatch` input default and the `|| '90'` env fallback the weekly cron uses).

## Why

`scripts/gha-image-age-check.sh` already provides full staleness coverage across all registries — Docker Hub `tag_last_pushed` for docker.io and `crane config .created` for ghcr.io/lscr.io/quay.io (which Renovate can't read a trusted timestamp from). It opens/auto-closes `stale-dependency` issues weekly.

Now that non-major container updates auto-merge after a soak — including ghcr/lscr/quay via the new `pr-cooldown` gate (DevSecNinja/.github#286) — a stale pinned image increasingly signals **upstream abandonment** or a **broken update path** rather than a merely pending update. A 90-day threshold surfaces those within ~3 months instead of a year.

## Trade-off

Expect `stale-dependency` issues for healthy-but-stable images that rebuild infrequently. If the noise is too high, we can add an allowlist for known-stable images as a follow-up.

## Validation

`actionlint`, `yamllint`, `yamlfmt -lint` all clean.