### PR TITLE
feat(ci): add Renovate PR cooldown caller workflow

### DIFF
--- a/.github/workflows/renovate-pr-cooldown.yml
+++ b/.github/workflows/renovate-pr-cooldown.yml
@@ -1,0 +1,32 @@
+---
+name: Renovate PR cooldown
+
+# Enforces the 14-day soak as a PR-age gate for Renovate PRs from registries
+# without a trusted release timestamp (ghcr.io / lscr.io / quay.io), which the
+# shared presets set to minimumReleaseAgeBehaviour=timestamp-optional. The
+# reusable workflow posts a required `pr-cooldown` status check that only turns
+# green once the PR branch head commit is >=14 days old; GitHub auto-merge then
+# merges. Human and non-gated PRs always get a passing status. See
+# DevSecNinja/.github docs/design-decisions/0005-pr-age-cooldown-for-untrusted-
+# timestamps.md and truenas-apps#115.
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch: # checkov:skip=CKV_GHA_7: Not a build workflow -- only posts a commit status.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  cooldown:
+    uses: DevSecNinja/.github/.github/workflows/renovate-pr-cooldown.yml@14651183caf76526c7596e60fce70437f6ad1831 # main
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write


### PR DESCRIPTION
## What

Adds the caller workflow that activates the shared **`pr-cooldown`** gate (DevSecNinja/.github#286) for this repo, pinned to `.github@14651183` (main).

## Why

The shared presets now set `minimumReleaseAgeBehaviour: "timestamp-optional"` for `ghcr.io` / `lscr.io` / `quay.io` images (no trusted registry timestamp), so Renovate opens their PRs immediately instead of blocking them forever (#115). This workflow re-introduces the 14-day soak as a required `pr-cooldown` status check measured from the PR branch head commit; GitHub auto-merge merges once it turns green. Human and non-gated PRs always receive a passing status, so the required check never blocks them.

Triggers: `pull_request` (seed status on open/rebase), `schedule` every 6h (flip to success once soaked), `workflow_dispatch` (manual seed).

## Activation — two steps (ordering matters)

1. **Merge this PR.** The workflow becomes active on `main`.
2. **Then** add `pr-cooldown` to the *Protect main branch* ruleset's **required status checks**. Doing this before step 1 would block open PRs (no producer yet). I'll run a `workflow_dispatch` to seed statuses on existing open PRs, then add the required check — or you can.

## Validation

`actionlint`, `yamllint`, `yamlfmt -lint`, `zizmor` (no findings), `checkov` (7 passed, 1 skipped: CKV_GHA_7) all clean.

Refs #115